### PR TITLE
Make aggregation retries more granular

### DIFF
--- a/src/aggregation/aggregation-tasks.service.ts
+++ b/src/aggregation/aggregation-tasks.service.ts
@@ -14,23 +14,14 @@ export class AggregationTasksService {
     if (!this.aggregationJobInProgress) {
       this.aggregationJobInProgress = true;
 
-      let success = false;
-      let executionNumber = 0;
-      //retry up to 3 times in case of error
-      while (!success && executionNumber < 3) {
-        try {
-          this.logger.debug('Starting Aggregations');
+      try {
+        this.logger.debug('Starting Aggregations');
 
-          await this.aggregationService.runAggregations();
-          success = true;
+        await this.aggregationService.runAggregations();
 
-          this.logger.debug('Finished Aggregations');
-        } catch (err) {
-          this.logger.error(
-            `Error during Aggregations job, execution ${executionNumber}: ${err}`,
-          );
-          executionNumber++;
-        }
+        this.logger.debug('Finished Aggregations');
+      } catch (err) {
+        this.logger.error(`Error during Aggregations job: ${err}`);
       }
 
       this.aggregationJobInProgress = false;


### PR DESCRIPTION
Current approach of retrying whole set of aggregations from scratch doesn't really work. It retries and just fails again after the same amount of time on the retry.
Additionally, looks like immediately retrying doesn't give enough time for primary server to process everything and next cancel comes very soon. Adding a 30s wait fixes that.