### PR TITLE
Fix SPs compliance percentage calculation

### DIFF
--- a/src/service/allocator/allocator.service.ts
+++ b/src/service/allocator/allocator.service.ts
@@ -436,7 +436,7 @@ export class AllocatorService {
             providers.includes(p.provider) &&
             validComplianceScores.includes(p.complianceScore),
         ).length) /
-      weekProvidersCompliance.length
+      providers.length
     );
   }
 }


### PR DESCRIPTION
This metric, for each allocator, should say the % of this allocator's SPs that are compliant.
`providers` contains a list of allocator's providers, while `weekProvidersCompliance` contains all providers known by the system that have their compliance score calculated.