### PR TITLE
Non-histogram sps-compliance endpoint

### DIFF
--- a/src/controller/stats/accumulative/allocators/allocators.controller.ts
+++ b/src/controller/stats/accumulative/allocators/allocators.controller.ts
@@ -3,7 +3,8 @@ import { AllocatorService } from '../../../../service/allocator/allocator.servic
 import { RetrievabilityWeekResponseDto } from '../../../../types/retrievabilityWeekResponse.dto';
 import { HistogramWeekResponseDto } from '../../../../types/histogramWeek.response.dto';
 import { SpsComplianceWeekResponseDto } from '../../../../types/spsComplianceWeekResponse.dto';
-import { ApiOkResponse } from '@nestjs/swagger';
+import { ApiOkResponse, ApiOperation } from '@nestjs/swagger';
+import { SpsComplianceHistogramWeekResponseDto } from 'src/types/spsComplianceHistogramWeekResponse.dto';
 
 @Controller('stats/acc/allocators')
 export class AllocatorsAccController {
@@ -24,6 +25,15 @@ export class AllocatorsAccController {
   }
 
   @Get('sps-compliance')
+  @ApiOperation({ deprecated: true })
+  @ApiOkResponse({ type: SpsComplianceHistogramWeekResponseDto })
+  async getAllocatorSpsComplianceHistogram(): Promise<SpsComplianceHistogramWeekResponseDto> {
+    return await this.allocatorAccService.getAllocatorSpsComplianceHistogram(
+      true,
+    );
+  }
+
+  @Get('sps-compliance-data')
   @ApiOkResponse({ type: SpsComplianceWeekResponseDto })
   async getAllocatorSpsCompliance(): Promise<SpsComplianceWeekResponseDto> {
     return await this.allocatorAccService.getAllocatorSpsCompliance(true);

--- a/src/service/allocator/allocator.service.ts
+++ b/src/service/allocator/allocator.service.ts
@@ -254,7 +254,7 @@ export class AllocatorService {
       for (const allocator in byAllocators) {
         const clients = byAllocators[allocator].map((p) => p.client);
 
-        const providers = isAccumulative
+        const providersRaw = isAccumulative
           ? await this.prismaService.client_provider_distribution_weekly_acc
               .findMany({
                 where: {
@@ -281,6 +281,7 @@ export class AllocatorService {
                 },
               })
               .then((r) => r.map((p) => p.provider));
+        const providers = [...new Set(providersRaw)];
 
         weekResult.push({
           id: allocator,

--- a/src/types/providerComplianceScoreRange.ts
+++ b/src/types/providerComplianceScoreRange.ts
@@ -1,5 +1,5 @@
 export enum ProviderComplianceScoreRange {
-  Zero, //0-0
-  OneOrTwo, //1-2
-  Three, //3-3
+  NonCompliant, //0-0
+  PartiallyCompliant, //1-2
+  Compliant, //3-3
 }

--- a/src/types/spsComplianceHistogramWeek.dto.ts
+++ b/src/types/spsComplianceHistogramWeek.dto.ts
@@ -1,0 +1,23 @@
+import { ProviderComplianceScoreRange } from './providerComplianceScoreRange';
+import { HistogramWeekResponseDto } from './histogramWeek.response.dto';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class SpsComplianceHistogramWeekDto {
+  @ApiProperty({ enum: ProviderComplianceScoreRange })
+  scoreRange: ProviderComplianceScoreRange;
+
+  @ApiProperty({ type: HistogramWeekResponseDto })
+  histogram: HistogramWeekResponseDto;
+
+  public static of(
+    scoreRange: ProviderComplianceScoreRange,
+    histogram: HistogramWeekResponseDto,
+  ) {
+    const dto = new SpsComplianceHistogramWeekDto();
+
+    dto.scoreRange = scoreRange;
+    dto.histogram = histogram;
+
+    return dto;
+  }
+}

--- a/src/types/spsComplianceHistogramWeekResponse.dto.ts
+++ b/src/types/spsComplianceHistogramWeekResponse.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { SpsComplianceHistogramWeekDto } from './spsComplianceHistogramWeek.dto';
+
+export class SpsComplianceHistogramWeekResponseDto {
+  @ApiProperty({ type: SpsComplianceHistogramWeekDto, isArray: true })
+  results: SpsComplianceHistogramWeekDto[];
+
+  constructor(results: SpsComplianceHistogramWeekDto[]) {
+    this.results = results;
+  }
+}

--- a/src/types/spsComplianceSingleAllocator.dto.ts
+++ b/src/types/spsComplianceSingleAllocator.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class SpsComplianceSingleAllocatorDto {
+  @ApiProperty({ type: String })
+  id: string;
+
+  @ApiProperty({ type: Number })
+  compliantSpsPercentage: number;
+
+  @ApiProperty({ type: Number })
+  partiallyCompliantSpsPercentage: number;
+
+  @ApiProperty({ type: Number })
+  nonCompliantSpsPercentage: number;
+}

--- a/src/types/spsComplianceWeek.dto.ts
+++ b/src/types/spsComplianceWeek.dto.ts
@@ -1,23 +1,17 @@
-import { ProviderComplianceScoreRange } from './providerComplianceScoreRange';
-import { HistogramWeekResponseDto } from './histogramWeek.response.dto';
 import { ApiProperty } from '@nestjs/swagger';
+import { SpsComplianceSingleAllocatorDto } from './spsComplianceSingleAllocator.dto';
 
 export class SpsComplianceWeekDto {
-  @ApiProperty({ enum: ProviderComplianceScoreRange })
-  scoreRange: ProviderComplianceScoreRange;
+  @ApiProperty({
+    type: String,
+    format: 'date',
+    example: '2024-04-22T00:00:00.000Z',
+  })
+  week: Date;
 
-  @ApiProperty({ type: HistogramWeekResponseDto })
-  histogram: HistogramWeekResponseDto;
+  @ApiProperty({ type: SpsComplianceSingleAllocatorDto, isArray: true })
+  allocators: SpsComplianceSingleAllocatorDto[];
 
-  public static of(
-    scoreRange: ProviderComplianceScoreRange,
-    histogram: HistogramWeekResponseDto,
-  ) {
-    const dto = new SpsComplianceWeekDto();
-
-    dto.scoreRange = scoreRange;
-    dto.histogram = histogram;
-
-    return dto;
-  }
+  @ApiProperty()
+  total: number;
 }


### PR DESCRIPTION
Mostly a refactor that exposes intermediate "calculationResults" of sps compliance as a dedicated endpoint. No real new logic.
It also marks the current `sps-compliance` endpoint as deprecated - we can remove it as soon as datacapstats FE gets updated to use the new one.