### PR TITLE
Ingest spark http retrievability data

### DIFF
--- a/prisma/migrations/20250121095832_spark_http/migration.sql
+++ b/prisma/migrations/20250121095832_spark_http/migration.sql
@@ -1,0 +1,25 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `retrievability_success_rate` on the `client_report_storage_provider_distribution` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "allocators_weekly" ADD COLUMN     "avg_weighted_retrievability_success_rate_http" DOUBLE PRECISION;
+
+-- AlterTable
+ALTER TABLE "allocators_weekly_acc" ADD COLUMN     "avg_weighted_retrievability_success_rate_http" DOUBLE PRECISION;
+
+-- AlterTable
+ALTER TABLE "client_report_storage_provider_distribution" DROP COLUMN "retrievability_success_rate",
+ADD COLUMN     "retrievability_success_rate_http" DOUBLE PRECISION;
+
+-- AlterTable
+ALTER TABLE "provider_retrievability_daily" ADD COLUMN     "success_rate_http" DOUBLE PRECISION,
+ADD COLUMN     "successful_http" INTEGER;
+
+-- AlterTable
+ALTER TABLE "providers_weekly" ADD COLUMN     "avg_retrievability_success_rate_http" DOUBLE PRECISION;
+
+-- AlterTable
+ALTER TABLE "providers_weekly_acc" ADD COLUMN     "avg_retrievability_success_rate_http" DOUBLE PRECISION;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -82,33 +82,37 @@ model client_replica_distribution {
 }
 
 model providers_weekly {
-  week                            DateTime
-  provider                        String
-  num_of_clients                  Int
-  biggest_client_total_deal_size  BigInt
-  total_deal_size                 BigInt
-  avg_retrievability_success_rate Float
+  week                                 DateTime
+  provider                             String
+  num_of_clients                       Int
+  biggest_client_total_deal_size       BigInt
+  total_deal_size                      BigInt
+  avg_retrievability_success_rate      Float
+  avg_retrievability_success_rate_http Float?
 
   @@id([week, provider])
 }
 
 model allocators_weekly {
-  week                                     DateTime
-  allocator                                String
-  num_of_clients                           Int
-  biggest_client_sum_of_allocations        BigInt
-  total_sum_of_allocations                 BigInt
-  avg_weighted_retrievability_success_rate Float
+  week                                          DateTime
+  allocator                                     String
+  num_of_clients                                Int
+  biggest_client_sum_of_allocations             BigInt
+  total_sum_of_allocations                      BigInt
+  avg_weighted_retrievability_success_rate      Float
+  avg_weighted_retrievability_success_rate_http Float?
 
   @@id([week, allocator])
 }
 
 model provider_retrievability_daily {
-  date         DateTime
-  provider     String
-  total        Int
-  successful   Int
-  success_rate Float
+  date              DateTime
+  provider          String
+  total             Int
+  successful        Int
+  success_rate      Float
+  successful_http   Int?
+  success_rate_http Float?
 
   @@id([date, provider])
 }
@@ -134,23 +138,25 @@ model client_provider_distribution_weekly_acc {
 }
 
 model providers_weekly_acc {
-  week                            DateTime
-  provider                        String
-  num_of_clients                  Int
-  biggest_client_total_deal_size  BigInt
-  total_deal_size                 BigInt
-  avg_retrievability_success_rate Float
+  week                                 DateTime
+  provider                             String
+  num_of_clients                       Int
+  biggest_client_total_deal_size       BigInt
+  total_deal_size                      BigInt
+  avg_retrievability_success_rate      Float
+  avg_retrievability_success_rate_http Float?
 
   @@id([week, provider])
 }
 
 model allocators_weekly_acc {
-  week                                     DateTime
-  allocator                                String
-  num_of_clients                           Int
-  biggest_client_sum_of_allocations        BigInt
-  total_sum_of_allocations                 BigInt
-  avg_weighted_retrievability_success_rate Float
+  week                                          DateTime
+  allocator                                     String
+  num_of_clients                                Int
+  biggest_client_sum_of_allocations             BigInt
+  total_sum_of_allocations                      BigInt
+  avg_weighted_retrievability_success_rate      Float
+  avg_weighted_retrievability_success_rate_http Float?
 
   @@id([week, allocator])
 }
@@ -169,14 +175,14 @@ model client_report {
 }
 
 model client_report_storage_provider_distribution {
-  id                          BigInt                                                @id @default(autoincrement()) @db.BigInt
-  client_report               client_report                                         @relation(fields: [client_report_id], references: [id])
-  client_report_id            BigInt                                                @db.BigInt
-  provider                    String
-  total_deal_size             BigInt
-  unique_data_size            BigInt
-  location                    client_report_storage_provider_distribution_location?
-  retrievability_success_rate Float?
+  id                               BigInt                                                @id @default(autoincrement()) @db.BigInt
+  client_report                    client_report                                         @relation(fields: [client_report_id], references: [id])
+  client_report_id                 BigInt                                                @db.BigInt
+  provider                         String
+  total_deal_size                  BigInt
+  unique_data_size                 BigInt
+  location                         client_report_storage_provider_distribution_location?
+  retrievability_success_rate_http Float?
 }
 
 model client_report_storage_provider_distribution_location {

--- a/prisma/sql/getAllocatorRetrievability.sql
+++ b/prisma/sql/getAllocatorRetrievability.sql
@@ -1,3 +1,5 @@
+-- TODO when business is ready switch from normal rate to http date
+-- question - do we do a cutoff date or just switch for past data as well?
 select
     ceil(avg_weighted_retrievability_success_rate*20)*5 - 5 as "valueFromExclusive",
     ceil(avg_weighted_retrievability_success_rate*20)*5 as "valueToInclusive",

--- a/prisma/sql/getAllocatorRetrievabilityAcc.sql
+++ b/prisma/sql/getAllocatorRetrievabilityAcc.sql
@@ -1,3 +1,5 @@
+-- TODO when business is ready switch from normal rate to http date
+-- question - do we do a cutoff date or just switch for past data as well?
 select
     ceil(avg_weighted_retrievability_success_rate*20)*5 - 5 as "valueFromExclusive",
     ceil(avg_weighted_retrievability_success_rate*20)*5 as "valueToInclusive",

--- a/prisma/sql/getAllocatorsWeekly.sql
+++ b/prisma/sql/getAllocatorsWeekly.sql
@@ -3,7 +3,8 @@ with
         select
             week,
             allocator,
-            sum(cpd.total_deal_size*coalesce(avg_retrievability_success_rate, 0))/sum(cpd.total_deal_size) as avg_weighted_retrievability_success_rate
+            sum(cpd.total_deal_size*coalesce(avg_retrievability_success_rate, 0))/sum(cpd.total_deal_size) as avg_weighted_retrievability_success_rate,
+            sum(cpd.total_deal_size*coalesce(avg_retrievability_success_rate_http, 0))/sum(cpd.total_deal_size) as avg_weighted_retrievability_success_rate_http
         from client_allocator_distribution_weekly
         inner join client_provider_distribution_weekly as cpd using (client, week)
         left join providers_weekly using (provider, week)
@@ -29,7 +30,8 @@ select
     num_of_clients::int,
     biggest_client_sum_of_allocations::bigint,
     total_sum_of_allocations::bigint,
-    coalesce(avg_weighted_retrievability_success_rate, 0) as avg_weighted_retrievability_success_rate
+    coalesce(avg_weighted_retrievability_success_rate, 0) as avg_weighted_retrievability_success_rate,
+    coalesce(avg_weighted_retrievability_success_rate_http, 0) as avg_weighted_retrievability_success_rate_http
 from allocator_stats
 left join allocator_retrievability
     using (week, allocator);

--- a/prisma/sql/getProvidersWeekly.sql
+++ b/prisma/sql/getProvidersWeekly.sql
@@ -4,19 +4,22 @@ with provider_retrievability_weekly as (
         provider,
         sum(total) as total,
         sum(successful) as successful,
-        sum(successful::float8)/sum(total::float8) as success_rate
+        sum(successful::float8)/sum(total::float8) as success_rate,
+        sum(coalesce(successful, 0)) as successful_http,
+        sum(coalesce(successful, 0)::float8)/sum(total::float8) as success_rate_http
     from provider_retrievability_daily
     group by
         week,
         provider
 )
-select  
+select
     week,
     provider,
     count(*)::int as num_of_clients,
     max(total_deal_size)::bigint as biggest_client_total_deal_size,
     sum(total_deal_size)::bigint as total_deal_size,
-    max(coalesce(success_rate, 0)) as avg_retrievability_success_rate
+    max(coalesce(success_rate, 0)) as avg_retrievability_success_rate,
+    max(coalesce(success_rate_http, 0)) as avg_retrievability_success_rate_http
 from client_provider_distribution_weekly
 left join provider_retrievability_weekly
     using (week, provider)

--- a/prisma/sql/getProvidersWeeklyAcc.sql
+++ b/prisma/sql/getProvidersWeeklyAcc.sql
@@ -5,19 +5,22 @@ with
             provider,
             sum(total) as total,
             sum(successful) as successful,
-            sum(successful::float8)/sum(total::float8) as success_rate
+            sum(successful::float8)/sum(total::float8) as success_rate,
+            sum(coalesce(successful_http, 0)) as successful_http,
+            sum(coalesce(successful_http, 0)::float8)/sum(total::float8) as success_rate_http
         from provider_retrievability_daily
         group by
             week,
             provider
     )
-select  
+select
     week,
     provider,
     count(*)::int as num_of_clients,
     max(total_deal_size)::bigint as biggest_client_total_deal_size,
     sum(total_deal_size)::bigint as total_deal_size,
-    max(coalesce(success_rate, 0)) as avg_retrievability_success_rate
+    max(coalesce(success_rate, 0)) as avg_retrievability_success_rate,
+    max(coalesce(success_rate_http, 0)) as avg_retrievability_success_rate_http
 from client_provider_distribution_weekly_acc as cpdwa
 left join provider_retrievability_weekly as prw using (week, provider)
 group by

--- a/src/aggregation/runners/allocators-acc.runner.ts
+++ b/src/aggregation/runners/allocators-acc.runner.ts
@@ -22,13 +22,15 @@ export class AllocatorsAccRunner implements AggregationRunner {
           biggest_client_sum_of_allocations: bigint | null;
           total_sum_of_allocations: bigint | null;
           avg_weighted_retrievability_success_rate: number | null;
+          avg_weighted_retrievability_success_rate_http: number | null;
         }>(postgresService.pool);
         const i = queryIterablePool.query(`with
                              allocator_retrievability as (
                                  select
                                      week,
                                      allocator,
-                                     sum(cpdwa.total_deal_size*coalesce(avg_retrievability_success_rate, 0))/sum(cpdwa.total_deal_size) as avg_weighted_retrievability_success_rate
+                                     sum(cpdwa.total_deal_size*coalesce(avg_retrievability_success_rate, 0))/sum(cpdwa.total_deal_size) as avg_weighted_retrievability_success_rate,
+                                     sum(cpdwa.total_deal_size*coalesce(avg_retrievability_success_rate_http, 0))/sum(cpdwa.total_deal_size) as avg_weighted_retrievability_success_rate_http
                                  from client_allocator_distribution_weekly_acc
                                           inner join client_provider_distribution_weekly_acc as cpdwa
                                                      using (client, week)
@@ -43,7 +45,8 @@ export class AllocatorsAccRunner implements AggregationRunner {
                              count(*)::int as num_of_clients,
                              max(sum_of_allocations)::bigint as biggest_client_sum_of_allocations,
                              sum(sum_of_allocations)::bigint as total_sum_of_allocations,
-                             max(coalesce(avg_weighted_retrievability_success_rate, 0)) as avg_weighted_retrievability_success_rate
+                             max(coalesce(avg_weighted_retrievability_success_rate, 0)) as avg_weighted_retrievability_success_rate,
+                             max(coalesce(avg_weighted_retrievability_success_rate_http, 0)) as avg_weighted_retrievability_success_rate_http
                          from client_allocator_distribution_weekly_acc
                                   left join allocator_retrievability
                                             using (week, allocator)
@@ -58,6 +61,7 @@ export class AllocatorsAccRunner implements AggregationRunner {
           biggest_client_sum_of_allocations: bigint | null;
           total_sum_of_allocations: bigint | null;
           avg_weighted_retrievability_success_rate: number | null;
+          avg_weighted_retrievability_success_rate_http: number | null;
         }[] = [];
 
         let isFirstInsert = true;
@@ -71,6 +75,8 @@ export class AllocatorsAccRunner implements AggregationRunner {
             total_sum_of_allocations: rowResult.total_sum_of_allocations,
             avg_weighted_retrievability_success_rate:
               rowResult.avg_weighted_retrievability_success_rate,
+            avg_weighted_retrievability_success_rate_http:
+              rowResult.avg_weighted_retrievability_success_rate_http,
           });
 
           if (data.length === 5000) {

--- a/src/aggregation/runners/allocators.runner.ts
+++ b/src/aggregation/runners/allocators.runner.ts
@@ -21,6 +21,8 @@ export class AllocatorsRunner implements AggregationRunner {
       total_sum_of_allocations: row.total_sum_of_allocations,
       avg_weighted_retrievability_success_rate:
         row.avg_weighted_retrievability_success_rate,
+      avg_weighted_retrievability_success_rate_http:
+        row.avg_weighted_retrievability_success_rate_http,
     }));
 
     await prismaService.$executeRaw`truncate allocators_weekly;`;

--- a/src/aggregation/runners/provider-retrievability-backfill.runner.ts
+++ b/src/aggregation/runners/provider-retrievability-backfill.runner.ts
@@ -51,6 +51,8 @@ export class ProviderRetrievabilityBackfillRunner implements AggregationRunner {
       total: parseInt(row.total),
       successful: parseInt(row.successful),
       success_rate: row.success_rate,
+      successful_http: parseInt(row.successful_http),
+      success_rate_http: row.success_rate_http,
     }));
 
     await prismaService.provider_retrievability_daily.createMany({ data });

--- a/src/aggregation/runners/provider-retrievability.runner.ts
+++ b/src/aggregation/runners/provider-retrievability.runner.ts
@@ -42,6 +42,8 @@ export class ProviderRetrievabilityRunner implements AggregationRunner {
       total: parseInt(row.total),
       successful: parseInt(row.successful),
       success_rate: row.success_rate,
+      successful_http: parseInt(row.successful_http),
+      success_rate_http: row.success_rate_http,
     }));
 
     await prismaService.provider_retrievability_daily.createMany({ data });

--- a/src/aggregation/runners/providers-acc.runner.ts
+++ b/src/aggregation/runners/providers-acc.runner.ts
@@ -20,6 +20,8 @@ export class ProvidersAccRunner implements AggregationRunner {
       biggest_client_total_deal_size: row.biggest_client_total_deal_size,
       total_deal_size: row.total_deal_size,
       avg_retrievability_success_rate: row.avg_retrievability_success_rate,
+      avg_retrievability_success_rate_http:
+        row.avg_retrievability_success_rate_http,
     }));
 
     await prismaService.$executeRaw`truncate providers_weekly_acc;`;

--- a/src/aggregation/runners/providers.runner.ts
+++ b/src/aggregation/runners/providers.runner.ts
@@ -20,6 +20,8 @@ export class ProvidersRunner implements AggregationRunner {
       biggest_client_total_deal_size: row.biggest_client_total_deal_size,
       total_deal_size: row.total_deal_size,
       avg_retrievability_success_rate: row.avg_retrievability_success_rate,
+      avg_retrievability_success_rate_http:
+        row.avg_retrievability_success_rate_http,
     }));
 
     await prismaService.$executeRaw`truncate providers_weekly;`;

--- a/src/service/allocator/allocator.service.ts
+++ b/src/service/allocator/allocator.service.ts
@@ -209,6 +209,9 @@ export class AllocatorService {
 
       const weekProvidersCompliance = weekProviders.map((wp) => {
         let complianceScore = 0;
+        // TODO when business is ready let's switch to using http success rate.
+        // Question - do we make a cutoff date for this? (like use normal rate
+        // till 25w4 and http rate after that)?
         if (
           wp.avg_retrievability_success_rate >
           thisWeekAverageRetrievability._avg.avg_retrievability_success_rate

--- a/src/service/client-report/client-report.service.ts
+++ b/src/service/client-report/client-report.service.ts
@@ -46,6 +46,7 @@ export class ClientReportService {
                 provider: provider.provider,
                 unique_data_size: provider.unique_data_size,
                 total_deal_size: provider.total_deal_size,
+                // TODO when business is ready switch to http success rate
                 retrievability_success_rate:
                   provider.retrievability_success_rate,
                 ...(provider.location && {

--- a/src/types/retrievabilityInfo.dto.ts
+++ b/src/types/retrievabilityInfo.dto.ts
@@ -3,4 +3,6 @@ export class RetrievabilityInfoDto {
   total: string;
   successful: string;
   success_rate: number;
+  successful_http: string;
+  success_rate_http: number;
 }


### PR DESCRIPTION
Focuses on ingesting the new data. All reports and histogram data for graphs still use normal rates, not http-only rates.