### PR TITLE
Fix client provider dist acc aggregation crashing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "eslint-plugin-prettier": "^5.2.1",
         "jest": "^29.7.0",
         "prettier": "^3.3.3",
-        "prisma": "^5.22.0",
+        "prisma": "^6.0.1",
         "source-map-support": "^0.5.21",
         "supertest": "^7.0.0",
         "ts-jest": "^29.2.5",
@@ -2999,48 +2999,53 @@
       }
     },
     "node_modules/@prisma/debug": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.22.0.tgz",
-      "integrity": "sha512-AUt44v3YJeggO2ZU5BkXI7M4hu9BF2zzH2iF2V5pyXT/lRTyWiElZ7It+bRH1EshoMRxHgpYg4VB6rCM+mG5jQ==",
-      "devOptional": true
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.2.1.tgz",
+      "integrity": "sha512-0KItvt39CmQxWkEw6oW+RQMD6RZ43SJWgEUnzxN8VC9ixMysa7MzZCZf22LCK5DSooiLNf8vM3LHZm/I/Ni7bQ==",
+      "devOptional": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.22.0.tgz",
-      "integrity": "sha512-UNjfslWhAt06kVL3CjkuYpHAWSO6L4kDCVPegV6itt7nD1kSJavd3vhgAEhjglLJJKEdJ7oIqDJ+yHk6qO8gPA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.2.1.tgz",
+      "integrity": "sha512-lTBNLJBCxVT9iP5I7Mn6GlwqAxTpS5qMERrhebkUhtXpGVkBNd/jHnNJBZQW4kGDCKaQg/r2vlJYkzOHnAb7ZQ==",
       "devOptional": true,
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "5.22.0",
-        "@prisma/engines-version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
-        "@prisma/fetch-engine": "5.22.0",
-        "@prisma/get-platform": "5.22.0"
+        "@prisma/debug": "6.2.1",
+        "@prisma/engines-version": "6.2.0-14.4123509d24aa4dede1e864b46351bf2790323b69",
+        "@prisma/fetch-engine": "6.2.1",
+        "@prisma/get-platform": "6.2.1"
       }
     },
     "node_modules/@prisma/engines-version": {
-      "version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2.tgz",
-      "integrity": "sha512-2PTmxFR2yHW/eB3uqWtcgRcgAbG1rwG9ZriSvQw+nnb7c4uCr3RAcGMb6/zfE88SKlC1Nj2ziUvc96Z379mHgQ==",
-      "devOptional": true
+      "version": "6.2.0-14.4123509d24aa4dede1e864b46351bf2790323b69",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.2.0-14.4123509d24aa4dede1e864b46351bf2790323b69.tgz",
+      "integrity": "sha512-7tw1qs/9GWSX6qbZs4He09TOTg1ff3gYsB3ubaVNN0Pp1zLm9NC5C5MZShtkz7TyQjx7blhpknB7HwEhlG+PrQ==",
+      "devOptional": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.22.0.tgz",
-      "integrity": "sha512-bkrD/Mc2fSvkQBV5EpoFcZ87AvOgDxbG99488a5cexp5Ccny+UM6MAe/UFkUC0wLYD9+9befNOqGiIJhhq+HbA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.2.1.tgz",
+      "integrity": "sha512-OO7O9d6Mrx2F9i+Gu1LW+DGXXyUFkP7OE5aj9iBfA/2jjDXEJjqa9X0ZmM9NZNo8Uo7ql6zKm6yjDcbAcRrw1A==",
       "devOptional": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "5.22.0",
-        "@prisma/engines-version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
-        "@prisma/get-platform": "5.22.0"
+        "@prisma/debug": "6.2.1",
+        "@prisma/engines-version": "6.2.0-14.4123509d24aa4dede1e864b46351bf2790323b69",
+        "@prisma/get-platform": "6.2.1"
       }
     },
     "node_modules/@prisma/get-platform": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.22.0.tgz",
-      "integrity": "sha512-pHhpQdr1UPFpt+zFfnPazhulaZYCUqeIcPpJViYoq9R+D/yw4fjE+CtnsnKzPYm0ddUbeXUzjGVGIRVgPDCk4Q==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.2.1.tgz",
+      "integrity": "sha512-zp53yvroPl5m5/gXYLz7tGCNG33bhG+JYCm74ohxOq1pPnrL47VQYFfF3RbTZ7TzGWCrR3EtoiYMywUBw7UK6Q==",
       "devOptional": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "5.22.0"
+        "@prisma/debug": "6.2.1"
       }
     },
     "node_modules/@prisma/instrumentation": {
@@ -9407,19 +9412,20 @@
       }
     },
     "node_modules/prisma": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.22.0.tgz",
-      "integrity": "sha512-vtpjW3XuYCSnMsNVBjLMNkTj6OZbudcPPTPYHqX0CJfpcdWciI1dM8uHETwmDxxiqEwCIE6WvXucWUetJgfu/A==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.2.1.tgz",
+      "integrity": "sha512-hhyM0H13pQleQ+br4CkzGizS5I0oInoeTw3JfLw1BRZduBSQxPILlJLwi+46wZzj9Je7ndyQEMGw/n5cN2fknA==",
       "devOptional": true,
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/engines": "5.22.0"
+        "@prisma/engines": "6.2.1"
       },
       "bin": {
         "prisma": "build/index.js"
       },
       "engines": {
-        "node": ">=16.13"
+        "node": ">=18.18"
       },
       "optionalDependencies": {
         "fsevents": "2.3.3"

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "eslint-plugin-prettier": "^5.2.1",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",
-    "prisma": "^5.22.0",
+    "prisma": "^6.0.1",
     "source-map-support": "^0.5.21",
     "supertest": "^7.0.0",
     "ts-jest": "^29.2.5",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,7 +1,7 @@
 generator client {
   provider        = "prisma-client-js"
   output          = "./generated/client"
-  previewFeatures = ["typedSql", "omitApi", "metrics"]
+  previewFeatures = ["typedSql", "metrics"]
 }
 
 datasource db {

--- a/prismaDmob/sql/getClientProviderDistributionAccSingleWeek.sql
+++ b/prismaDmob/sql/getClientProviderDistributionAccSingleWeek.sql
@@ -1,0 +1,26 @@
+with miner_pieces as (
+    select
+        "pieceCid" as piece_cid,
+        'f0' || "clientId" as client,
+        'f0' || "providerId" as provider,
+        sum("pieceSize") as total_deal_size,
+        min("pieceSize") as piece_size
+    from unified_verified_deal
+    where
+        "termStart" >= 3847920 -- nv22 start
+        and date_trunc('week', to_timestamp("termStart" * 30 + 1598306400)) <= $1 -- deals up to provided week
+    group by
+      "pieceCid",
+      "clientId",
+      "providerId"
+)
+
+select
+    client,
+    provider,
+    sum(total_deal_size)::bigint as total_deal_size,
+    sum(piece_size)::bigint as unique_data_size
+from miner_pieces
+group by client, provider;
+
+

--- a/src/aggregation/runners/allocators-acc.runner.ts
+++ b/src/aggregation/runners/allocators-acc.runner.ts
@@ -99,7 +99,7 @@ export class AllocatorsAccRunner implements AggregationRunner {
               getDataEndTimerMetric();
               storeDataEndTimerMetric =
                 startStoreDataTimerByRunnerNameMetric(runnerName);
-              await tx.$executeRaw`truncate allocators_weekly_acc`;
+              await tx.$executeRaw`delete from allocators_weekly_acc`;
             }
 
             await tx.allocators_weekly_acc.createMany({
@@ -115,7 +115,7 @@ export class AllocatorsAccRunner implements AggregationRunner {
             getDataEndTimerMetric();
             storeDataEndTimerMetric =
               startStoreDataTimerByRunnerNameMetric(runnerName);
-            await tx.$executeRaw`truncate allocators_weekly_acc`;
+            await tx.$executeRaw`delete from allocators_weekly_acc`;
           }
 
           await tx.allocators_weekly_acc.createMany({

--- a/src/aggregation/runners/allocators-acc.runner.ts
+++ b/src/aggregation/runners/allocators-acc.runner.ts
@@ -65,8 +65,6 @@ export class AllocatorsAccRunner implements AggregationRunner {
                              week,
                              allocator;`);
 
-        getDataEndTimerMetric();
-
         const data: {
           week: Date;
           allocator: string;
@@ -79,8 +77,7 @@ export class AllocatorsAccRunner implements AggregationRunner {
 
         let isFirstInsert = true;
 
-        const storeDataEndTimerMetric =
-          startStoreDataTimerByRunnerNameMetric(runnerName);
+        let storeDataEndTimerMetric;
 
         for await (const rowResult of i) {
           data.push({
@@ -98,8 +95,11 @@ export class AllocatorsAccRunner implements AggregationRunner {
 
           if (data.length === 5000) {
             if (isFirstInsert) {
-              await tx.$executeRaw`truncate allocators_weekly_acc`;
               isFirstInsert = false;
+              getDataEndTimerMetric();
+              storeDataEndTimerMetric =
+                startStoreDataTimerByRunnerNameMetric(runnerName);
+              await tx.$executeRaw`truncate allocators_weekly_acc`;
             }
 
             await tx.allocators_weekly_acc.createMany({
@@ -112,6 +112,9 @@ export class AllocatorsAccRunner implements AggregationRunner {
 
         if (data.length > 0) {
           if (isFirstInsert) {
+            getDataEndTimerMetric();
+            storeDataEndTimerMetric =
+              startStoreDataTimerByRunnerNameMetric(runnerName);
             await tx.$executeRaw`truncate allocators_weekly_acc`;
           }
 

--- a/src/aggregation/runners/allocators.runner.ts
+++ b/src/aggregation/runners/allocators.runner.ts
@@ -41,7 +41,7 @@ export class AllocatorsRunner implements AggregationRunner {
     const storeDataEndTimerMetric =
       startStoreDataTimerByRunnerNameMetric(runnerName);
 
-    await prismaService.$executeRaw`truncate allocators_weekly;`;
+    await prismaService.$executeRaw`delete from allocators_weekly;`;
     await prismaService.allocators_weekly.createMany({ data });
 
     storeDataEndTimerMetric();

--- a/src/aggregation/runners/cid-sharing.runner.ts
+++ b/src/aggregation/runners/cid-sharing.runner.ts
@@ -35,7 +35,7 @@ export class CidSharingRunner implements AggregationRunner {
     const storeDataEndTimerMetric =
       startStoreDataTimerByRunnerNameMetric(runnerName);
 
-    await prismaService.$executeRaw`truncate cid_sharing;`;
+    await prismaService.$executeRaw`delete from cid_sharing;`;
     await prismaService.cid_sharing.createMany({ data });
 
     storeDataEndTimerMetric();

--- a/src/aggregation/runners/client-allocator-distribution-acc.runner.ts
+++ b/src/aggregation/runners/client-allocator-distribution-acc.runner.ts
@@ -37,7 +37,7 @@ export class ClientAllocatorDistributionAccRunner implements AggregationRunner {
     const storeDataEndTimerMetric =
       startStoreDataTimerByRunnerNameMetric(runnerName);
 
-    await prismaService.$executeRaw`truncate client_allocator_distribution_weekly_acc;`;
+    await prismaService.$executeRaw`delete from client_allocator_distribution_weekly_acc;`;
     await prismaService.client_allocator_distribution_weekly_acc.createMany({
       data,
     });

--- a/src/aggregation/runners/client-allocator-distribution.runner.ts
+++ b/src/aggregation/runners/client-allocator-distribution.runner.ts
@@ -37,7 +37,7 @@ export class ClientAllocatorDistributionRunner implements AggregationRunner {
     const storeDataEndTimerMetric =
       startStoreDataTimerByRunnerNameMetric(runnerName);
 
-    await prismaService.$executeRaw`truncate client_allocator_distribution_weekly;`;
+    await prismaService.$executeRaw`delete from client_allocator_distribution_weekly;`;
     await prismaService.client_allocator_distribution_weekly.createMany({
       data,
     });

--- a/src/aggregation/runners/client-claims.runner.ts
+++ b/src/aggregation/runners/client-claims.runner.ts
@@ -57,7 +57,7 @@ export class ClientClaimsRunner implements AggregationRunner {
               getDataEndTimerMetric();
               storeDataEndTimerMetric =
                 startStoreDataTimerByRunnerNameMetric(runnerName);
-              await tx.$executeRaw`truncate client_claims_hourly`;
+              await tx.$executeRaw`delete from client_claims_hourly`;
             }
 
             await tx.client_claims_hourly.createMany({
@@ -73,7 +73,7 @@ export class ClientClaimsRunner implements AggregationRunner {
             getDataEndTimerMetric();
             storeDataEndTimerMetric =
               startStoreDataTimerByRunnerNameMetric(runnerName);
-            await tx.$executeRaw`truncate client_claims_hourly`;
+            await tx.$executeRaw`delete from client_claims_hourly`;
           }
           await tx.client_claims_hourly.createMany({
             data,

--- a/src/aggregation/runners/client-provider-distribution-acc.runner.ts
+++ b/src/aggregation/runners/client-provider-distribution-acc.runner.ts
@@ -62,8 +62,6 @@ export class ClientProviderDistributionAccRunner implements AggregationRunner {
                                                   client,
                                                   provider;`);
 
-        getDataEndTimerMetric();
-
         const data: {
           week: Date | null;
           client: string | null;
@@ -74,8 +72,7 @@ export class ClientProviderDistributionAccRunner implements AggregationRunner {
 
         let isFirstInsert = true;
 
-        const storeDataEndTimerMetric =
-          startStoreDataTimerByRunnerNameMetric(runnerName);
+        let storeDataEndTimerMetric;
 
         for await (const rowResult of i) {
           data.push({
@@ -88,6 +85,9 @@ export class ClientProviderDistributionAccRunner implements AggregationRunner {
 
           if (data.length === 5000) {
             if (isFirstInsert) {
+              getDataEndTimerMetric();
+              storeDataEndTimerMetric =
+                startStoreDataTimerByRunnerNameMetric(runnerName);
               await tx.$executeRaw`truncate client_provider_distribution_weekly_acc`;
               isFirstInsert = false;
             }
@@ -102,6 +102,9 @@ export class ClientProviderDistributionAccRunner implements AggregationRunner {
 
         if (data.length > 0) {
           if (isFirstInsert) {
+            getDataEndTimerMetric();
+            storeDataEndTimerMetric =
+              startStoreDataTimerByRunnerNameMetric(runnerName);
             await tx.$executeRaw`truncate client_provider_distribution_weekly_acc`;
           }
           await tx.client_provider_distribution_weekly_acc.createMany({

--- a/src/aggregation/runners/client-provider-distribution-acc.runner.ts
+++ b/src/aggregation/runners/client-provider-distribution-acc.runner.ts
@@ -1,4 +1,6 @@
-import { QueryIterablePool } from 'pg-iterator';
+import { Logger } from '@nestjs/common';
+import { DateTime } from 'luxon';
+import { getClientProviderDistributionAccSingleWeek } from 'prismaDmob/generated/client/sql';
 import {
   AggregationRunner,
   AggregationRunnerRunServices,
@@ -6,117 +8,72 @@ import {
 import { AggregationTable } from '../aggregation-table';
 
 export class ClientProviderDistributionAccRunner implements AggregationRunner {
+  private readonly logger = new Logger(
+    ClientProviderDistributionAccRunner.name,
+  );
+
   public async run({
     prismaService,
-    postgresDmobService,
+    prismaDmobService,
     prometheusMetricService,
   }: AggregationRunnerRunServices): Promise<void> {
     const runnerName = this.getName();
-
     const {
       startGetDataTimerByRunnerNameMetric,
       startStoreDataTimerByRunnerNameMetric,
     } = prometheusMetricService.aggregateMetrics;
 
-    await prismaService.$transaction(
-      async (tx) => {
-        const getDataEndTimerMetric =
-          startGetDataTimerByRunnerNameMetric(runnerName);
+    //const latestStored =
+    //  await prismaService.client_provider_distribution_weekly_acc.findFirst({
+    //    select: {
+    //      week: true,
+    //    },
+    //    orderBy: {
+    //      week: 'desc',
+    //    },
+    //  });
+    //let nextWeek = latestStored
+    //  ? DateTime.fromJSDate(latestStored.date, { zone: 'UTC' }) // we want to reprocess the last stored week, as it might've been incomplete
+    //  : DateTime.fromSeconds(3847920 * 30 + 1598306400).startOf('week'); // nv22 start week - a.k.a. reprocess everything
+    let nextWeek = DateTime.fromSeconds(3847920 * 30 + 1598306400).startOf(
+      'week',
+    ); // nv22 start week
 
-        const queryIterablePool = new QueryIterablePool<{
-          week: Date | null;
-          client: string | null;
-          provider: string | null;
-          total_deal_size: bigint | null;
-          unique_data_size: bigint | null;
-        }>(postgresDmobService.pool);
+    const now = DateTime.now().setZone('UTC');
+    while (nextWeek <= now) {
+      this.logger.debug(`Processing week ${nextWeek}`);
+      const getDataEndTimerMetric =
+        startGetDataTimerByRunnerNameMetric(runnerName);
+      const result = await prismaDmobService.$queryRawTyped(
+        getClientProviderDistributionAccSingleWeek(nextWeek.toJSDate()),
+      );
+      getDataEndTimerMetric();
 
-        const i = queryIterablePool.query(`with miner_pieces
-                                                  as (select date_trunc('week', to_timestamp("termStart" * 30 + 1598306400)) as week,
-                                                             'f0' || "clientId"                                              as client,
-                                                             'f0' || "providerId"                                            as provider,
-                                                             "pieceCid",
-                                                             sum("pieceSize")                                                as total_deal_size,
-                                                             min("pieceSize")                                                as piece_size
-                                                      from unified_verified_deal
-                                                      where "termStart" >= 3847920                                           -- nv22 start
-                                                        and to_timestamp("termStart" * 30 + 1598306400) <= current_timestamp -- deals that didn't start yet
-                                                      group by week,
-                                                               client,
-                                                               provider,
-                                                               "pieceCid"),
-                                              weeks as (select date_trunc('week', dates) week
-                                                        from generate_series(
-                                                                     to_timestamp(3847920 * 30 + 1598306400),
-                                                                     current_timestamp,
-                                                                     '1 week'::interval) dates)
-                                         select weeks.week                   as week,
-                                                client,
-                                                provider,
-                                                sum(total_deal_size)::bigint as total_deal_size,
-                                                sum(piece_size)::bigint      as unique_data_size
-                                         from weeks
-                                                  inner join miner_pieces
-                                                             on weeks.week >= miner_pieces.week
-                                         group by weeks.week,
-                                                  client,
-                                                  provider;`);
+      const storeDataEndTimerMetric =
+        startStoreDataTimerByRunnerNameMetric(runnerName);
+      const data = result.map((dmobResult) => ({
+        week: nextWeek.toJSDate(),
+        client: dmobResult.client,
+        provider: dmobResult.provider,
+        total_deal_size: dmobResult.total_deal_size,
+        unique_data_size: dmobResult.unique_data_size,
+      }));
+      await prismaService.$transaction(async (tx) => {
+        await tx.client_provider_distribution_weekly_acc.deleteMany({
+          where: {
+            week: {
+              equals: nextWeek.toJSDate(),
+            },
+          },
+        });
+        await tx.client_provider_distribution_weekly_acc.createMany({
+          data,
+        });
+      });
+      storeDataEndTimerMetric();
 
-        const data: {
-          week: Date | null;
-          client: string | null;
-          provider: string | null;
-          total_deal_size: bigint | null;
-          unique_data_size: bigint | null;
-        }[] = [];
-
-        let isFirstInsert = true;
-
-        let storeDataEndTimerMetric;
-
-        for await (const rowResult of i) {
-          data.push({
-            week: rowResult.week,
-            client: rowResult.client,
-            provider: rowResult.provider,
-            total_deal_size: rowResult.total_deal_size,
-            unique_data_size: rowResult.unique_data_size,
-          });
-
-          if (data.length === 5000) {
-            if (isFirstInsert) {
-              getDataEndTimerMetric();
-              storeDataEndTimerMetric =
-                startStoreDataTimerByRunnerNameMetric(runnerName);
-              await tx.$executeRaw`delete from client_provider_distribution_weekly_acc`;
-              isFirstInsert = false;
-            }
-
-            await tx.client_provider_distribution_weekly_acc.createMany({
-              data,
-            });
-
-            data.length = 0;
-          }
-        }
-
-        if (data.length > 0) {
-          if (isFirstInsert) {
-            getDataEndTimerMetric();
-            storeDataEndTimerMetric =
-              startStoreDataTimerByRunnerNameMetric(runnerName);
-            await tx.$executeRaw`delete from client_provider_distribution_weekly_acc`;
-          }
-          await tx.client_provider_distribution_weekly_acc.createMany({
-            data,
-          });
-        }
-        storeDataEndTimerMetric();
-      },
-      {
-        timeout: Number.MAX_SAFE_INTEGER,
-      },
-    );
+      nextWeek = nextWeek.plus({ weeks: 1 });
+    }
   }
 
   getFilledTables(): AggregationTable[] {

--- a/src/aggregation/runners/client-provider-distribution-acc.runner.ts
+++ b/src/aggregation/runners/client-provider-distribution-acc.runner.ts
@@ -88,7 +88,7 @@ export class ClientProviderDistributionAccRunner implements AggregationRunner {
               getDataEndTimerMetric();
               storeDataEndTimerMetric =
                 startStoreDataTimerByRunnerNameMetric(runnerName);
-              await tx.$executeRaw`truncate client_provider_distribution_weekly_acc`;
+              await tx.$executeRaw`delete from client_provider_distribution_weekly_acc`;
               isFirstInsert = false;
             }
 
@@ -105,7 +105,7 @@ export class ClientProviderDistributionAccRunner implements AggregationRunner {
             getDataEndTimerMetric();
             storeDataEndTimerMetric =
               startStoreDataTimerByRunnerNameMetric(runnerName);
-            await tx.$executeRaw`truncate client_provider_distribution_weekly_acc`;
+            await tx.$executeRaw`delete from client_provider_distribution_weekly_acc`;
           }
           await tx.client_provider_distribution_weekly_acc.createMany({
             data,

--- a/src/aggregation/runners/client-provider-distribution-weekly.runner.ts
+++ b/src/aggregation/runners/client-provider-distribution-weekly.runner.ts
@@ -39,7 +39,7 @@ export class ClientProviderDistributionWeeklyRunner
     const storeDataEndTimerMetric =
       startStoreDataTimerByRunnerNameMetric(runnerName);
 
-    await prismaService.$executeRaw`truncate client_provider_distribution_weekly;`;
+    await prismaService.$executeRaw`delete from client_provider_distribution_weekly;`;
     await prismaService.client_provider_distribution_weekly.createMany({
       data,
     });

--- a/src/aggregation/runners/client-provider-distribution.runner.ts
+++ b/src/aggregation/runners/client-provider-distribution.runner.ts
@@ -37,7 +37,7 @@ export class ClientProviderDistributionRunner implements AggregationRunner {
     const storeDataEndTimerMetric =
       startStoreDataTimerByRunnerNameMetric(runnerName);
 
-    await prismaService.$executeRaw`truncate client_provider_distribution;`;
+    await prismaService.$executeRaw`delete from client_provider_distribution;`;
     await prismaService.client_provider_distribution.createMany({
       data,
     });

--- a/src/aggregation/runners/client-replica-distribution.runner.ts
+++ b/src/aggregation/runners/client-replica-distribution.runner.ts
@@ -36,7 +36,7 @@ export class ClientReplicaDistributionRunner implements AggregationRunner {
     const storeDataEndTimerMetric =
       startStoreDataTimerByRunnerNameMetric(runnerName);
 
-    await prismaService.$executeRaw`truncate client_replica_distribution;`;
+    await prismaService.$executeRaw`delete from client_replica_distribution;`;
     await prismaService.client_replica_distribution.createMany({ data });
 
     storeDataEndTimerMetric();

--- a/src/aggregation/runners/provider-first-client.runner.ts
+++ b/src/aggregation/runners/provider-first-client.runner.ts
@@ -31,7 +31,7 @@ export class ProviderFirstClientRunner implements AggregationRunner {
     const storeDataEndTimerMetric =
       startStoreDataTimerByRunnerNameMetric(runnerName);
 
-    await prismaService.$executeRaw`truncate provider_first_client;`;
+    await prismaService.$executeRaw`delete from provider_first_client;`;
     await prismaService.provider_first_client.createMany({ data });
 
     storeDataEndTimerMetric();

--- a/src/aggregation/runners/providers-acc.runner.ts
+++ b/src/aggregation/runners/providers-acc.runner.ts
@@ -40,7 +40,7 @@ export class ProvidersAccRunner implements AggregationRunner {
     const storeDataEndTimerMetric =
       startStoreDataTimerByRunnerNameMetric(runnerName);
 
-    await prismaService.$executeRaw`truncate providers_weekly_acc;`;
+    await prismaService.$executeRaw`delete from providers_weekly_acc;`;
     await prismaService.providers_weekly_acc.createMany({ data });
     storeDataEndTimerMetric();
   }

--- a/src/aggregation/runners/providers.runner.ts
+++ b/src/aggregation/runners/providers.runner.ts
@@ -40,7 +40,7 @@ export class ProvidersRunner implements AggregationRunner {
     const storeDataEndTimerMetric =
       startStoreDataTimerByRunnerNameMetric(runnerName);
 
-    await prismaService.$executeRaw`truncate providers_weekly;`;
+    await prismaService.$executeRaw`delete from providers_weekly;`;
     await prismaService.providers_weekly.createMany({ data });
     storeDataEndTimerMetric();
   }

--- a/src/aggregation/runners/unified-verified-deal.runner.ts
+++ b/src/aggregation/runners/unified-verified-deal.runner.ts
@@ -69,7 +69,7 @@ export class UnifiedVerifiedDealRunner implements AggregationRunner {
               getDataEndTimerMetric();
               storeDataEndTimerMetric =
                 startStoreDataTimerByRunnerNameMetric(runnerName);
-              await tx.$executeRaw`truncate unified_verified_deal_hourly`;
+              await tx.$executeRaw`delete from unified_verified_deal_hourly`;
               isFirstInsert = false;
             }
 
@@ -86,7 +86,7 @@ export class UnifiedVerifiedDealRunner implements AggregationRunner {
             getDataEndTimerMetric();
             storeDataEndTimerMetric =
               startStoreDataTimerByRunnerNameMetric(runnerName);
-            await tx.$executeRaw`truncate unified_verified_deal_hourly`;
+            await tx.$executeRaw`delete from unified_verified_deal_hourly`;
           }
           await tx.unified_verified_deal_hourly.createMany({
             data,

--- a/src/aggregation/runners/unified-verified-deal.runner.ts
+++ b/src/aggregation/runners/unified-verified-deal.runner.ts
@@ -43,8 +43,6 @@ export class UnifiedVerifiedDealRunner implements AggregationRunner {
                                           client,
                                           provider;`);
 
-        getDataEndTimerMetric();
-
         const data: {
           hour: Date | null;
           client: string | null;
@@ -55,8 +53,7 @@ export class UnifiedVerifiedDealRunner implements AggregationRunner {
 
         let isFirstInsert = true;
 
-        const storeDataEndTimerMetric =
-          startStoreDataTimerByRunnerNameMetric(runnerName);
+        let storeDataEndTimerMetric;
 
         for await (const rowResult of i) {
           data.push({
@@ -69,6 +66,9 @@ export class UnifiedVerifiedDealRunner implements AggregationRunner {
 
           if (data.length === 5000) {
             if (isFirstInsert) {
+              getDataEndTimerMetric();
+              storeDataEndTimerMetric =
+                startStoreDataTimerByRunnerNameMetric(runnerName);
               await tx.$executeRaw`truncate unified_verified_deal_hourly`;
               isFirstInsert = false;
             }
@@ -83,6 +83,9 @@ export class UnifiedVerifiedDealRunner implements AggregationRunner {
 
         if (data.length > 0) {
           if (isFirstInsert) {
+            getDataEndTimerMetric();
+            storeDataEndTimerMetric =
+              startStoreDataTimerByRunnerNameMetric(runnerName);
             await tx.$executeRaw`truncate unified_verified_deal_hourly`;
           }
           await tx.unified_verified_deal_hourly.createMany({


### PR DESCRIPTION
This PR:
1. Bumps prisma CLI to match @prisma/client version
2. Fixes measuring query & store time metrics in "streaming" cases
3. Switches from `truncate` to `delete all` for data consistency (though this will need to be monitored closely by @lukasz-wal to make sure the DB can handle vacuuming this)
4. Changes client-provider-distribution-acc to process data week by week instead of all at once to avoid blowing up DMOB DB. After changes it takes 1-3 minutes per week and it needs ~2G of temporary disk space on DMOB DB.

The biggest issue I see that this new aggregation on it's own requires ~2h. But that's a temporary until we switch to the incremental version, which will take <5 minutes.