### PR TITLE
Make client-provider-distribution-acc aggregation somewhat incremental

### DIFF
--- a/src/aggregation/runners/client-provider-distribution-acc.runner.ts
+++ b/src/aggregation/runners/client-provider-distribution-acc.runner.ts
@@ -23,21 +23,18 @@ export class ClientProviderDistributionAccRunner implements AggregationRunner {
       startStoreDataTimerByRunnerNameMetric,
     } = prometheusMetricService.aggregateMetrics;
 
-    //const latestStored =
-    //  await prismaService.client_provider_distribution_weekly_acc.findFirst({
-    //    select: {
-    //      week: true,
-    //    },
-    //    orderBy: {
-    //      week: 'desc',
-    //    },
-    //  });
-    //let nextWeek = latestStored
-    //  ? DateTime.fromJSDate(latestStored.date, { zone: 'UTC' }) // we want to reprocess the last stored week, as it might've been incomplete
-    //  : DateTime.fromSeconds(3847920 * 30 + 1598306400).startOf('week'); // nv22 start week - a.k.a. reprocess everything
-    let nextWeek = DateTime.fromSeconds(3847920 * 30 + 1598306400).startOf(
-      'week',
-    ); // nv22 start week
+    const latestStored =
+      await prismaService.client_provider_distribution_weekly_acc.findFirst({
+        select: {
+          week: true,
+        },
+        orderBy: {
+          week: 'desc',
+        },
+      });
+    let nextWeek = latestStored
+      ? DateTime.fromJSDate(latestStored.week, { zone: 'UTC' }) // we want to reprocess the last stored week, as it might've been incomplete
+      : DateTime.fromSeconds(3847920 * 30 + 1598306400).startOf('week'); // nv22 start week - a.k.a. reprocess everything
 
     const now = DateTime.now().setZone('UTC');
     while (nextWeek <= now) {


### PR DESCRIPTION
It's not 100% incremental, as we're reprocessing last week every time, but it's better than processing all since april.
See https://github.com/fidlabs/compliance-data-platform/pull/65#discussion_r1987434653 for background info.