### PR TITLE
 Add per-allocator and per-client stats to old-datacap endpoints 

### DIFF
--- a/src/aggregation/aggregation-tasks.service.ts
+++ b/src/aggregation/aggregation-tasks.service.ts
@@ -33,7 +33,7 @@ export class AggregationTasksService extends HealthIndicator {
     throw new HealthCheckError('Healthcheck failed', result);
   }
 
-  @Cron(CronExpression.EVERY_2_HOURS)
+  @Cron(CronExpression.EVERY_HOUR)
   public async runAggregationJob() {
     if (!this.jobInProgress) {
       this.jobInProgress = true;

--- a/src/service/old-datacap/old-datacap.service.ts
+++ b/src/service/old-datacap/old-datacap.service.ts
@@ -6,6 +6,7 @@ import {
   OldDatacapClientBalanceWeek,
   OldDatacapClientBalanceWeekResponse,
 } from './types.old-datacap';
+import { groupBy } from 'lodash';
 
 @Injectable()
 export class OldDatacapService {
@@ -14,7 +15,7 @@ export class OldDatacapService {
   constructor(private readonly prismaService: PrismaService) {}
 
   public async getAllocatorBalance(): Promise<OldDatacapAllocatorBalanceWeekResponse> {
-    const dbResults =
+    const aggResults =
       await this.prismaService.old_datacap_balance_weekly.groupBy({
         by: ['week'],
         _count: {
@@ -30,11 +31,42 @@ export class OldDatacapService {
         },
       });
 
-    const results: OldDatacapAllocatorBalanceWeek[] = dbResults.map((r) => ({
+    const allRows =
+      await this.prismaService.old_datacap_balance_weekly.findMany({
+        where: {
+          OR: [
+            {
+              old_dc_balance: {
+                gt: 0,
+              },
+            },
+            {
+              allocations: {
+                gt: 0,
+              },
+            },
+          ],
+        },
+      });
+    const allocatorData = allRows.map((r) => ({
+      week: r.week.toISOString(),
+      allocator: r.allocator,
+      oldDatacap: r.old_dc_balance,
+      allocations: r.allocations,
+    }));
+    const byWeek = groupBy(allocatorData, (row) => row.week);
+
+    const results: OldDatacapAllocatorBalanceWeek[] = aggResults.map((r) => ({
       week: r.week,
       allocators: r._count.allocator,
       oldDatacap: r._sum.old_dc_balance,
       allocations: r._sum.allocations,
+      drilldown:
+        byWeek[r.week.toISOString()].map((v) => ({
+          allocator: v.allocator,
+          oldDatacap: v.oldDatacap,
+          allocations: v.allocations,
+        })) ?? [],
     }));
 
     return { results };
@@ -56,11 +88,43 @@ export class OldDatacapService {
           week: 'asc',
         },
       });
+
+    const allRows =
+      await this.prismaService.old_datacap_client_balance_weekly.findMany({
+        where: {
+          OR: [
+            {
+              old_dc_balance: {
+                gt: 0,
+              },
+            },
+            {
+              claims: {
+                gt: 0,
+              },
+            },
+          ],
+        },
+      });
+    const clientData = allRows.map((r) => ({
+      week: r.week.toISOString(),
+      client: r.client,
+      oldDatacap: r.old_dc_balance,
+      claims: r.claims,
+    }));
+    const byWeek = groupBy(clientData, (row) => row.week);
+
     const results: OldDatacapClientBalanceWeek[] = dbResults.map((r) => ({
       week: r.week,
       clients: r._count.client,
       oldDatacap: r._sum.old_dc_balance,
       claims: r._sum.claims,
+      drilldown:
+        byWeek[r.week.toISOString()].map((v) => ({
+          client: v.client,
+          oldDatacap: v.oldDatacap,
+          claims: v.claims,
+        })) ?? [],
     }));
     return { results };
   }

--- a/src/service/old-datacap/types.old-datacap.ts
+++ b/src/service/old-datacap/types.old-datacap.ts
@@ -1,5 +1,22 @@
 import { ApiProperty } from '@nestjs/swagger';
 
+export class OldDatacapAllocatorBalance {
+  @ApiProperty({
+    description: 'Allocator ID',
+  })
+  allocator: string;
+
+  @ApiProperty({
+    description: 'Old datacap owned by the allocator',
+  })
+  oldDatacap: bigint;
+
+  @ApiProperty({
+    description: 'Old datacap allocated by the allocator',
+  })
+  allocations: bigint;
+}
+
 export class OldDatacapAllocatorBalanceWeek {
   @ApiProperty({
     type: String,
@@ -22,6 +39,13 @@ export class OldDatacapAllocatorBalanceWeek {
     description: 'Number of allocators holding old datacap',
   })
   allocators: number;
+
+  @ApiProperty({
+    isArray: true,
+    type: OldDatacapAllocatorBalance,
+    description: 'Data on specific allocators',
+  })
+  drilldown: OldDatacapAllocatorBalance[];
 }
 
 export class OldDatacapAllocatorBalanceWeekResponse {
@@ -31,6 +55,23 @@ export class OldDatacapAllocatorBalanceWeekResponse {
     isArray: true,
   })
   results: OldDatacapAllocatorBalanceWeek[];
+}
+
+export class OldDatacapClientBalance {
+  @ApiProperty({
+    description: 'Client ID',
+  })
+  client: string;
+
+  @ApiProperty({
+    description: 'Old datacap owned by the client',
+  })
+  oldDatacap: bigint;
+
+  @ApiProperty({
+    description: 'Old datacap spent by the client',
+  })
+  claims: bigint;
 }
 
 export class OldDatacapClientBalanceWeek {
@@ -55,6 +96,13 @@ export class OldDatacapClientBalanceWeek {
     description: 'Number of clients holding old datacap',
   })
   clients: number;
+
+  @ApiProperty({
+    isArray: true,
+    type: OldDatacapClientBalance,
+    description: 'Data on specific client',
+  })
+  drilldown: OldDatacapClientBalance[];
 }
 
 export class OldDatacapClientBalanceWeekResponse {


### PR DESCRIPTION
Expose detailed old datacap data on API.
The responses are quite big. ~300KiB for allocator-balance and ~7MiB for client-balance. If it turns out this is too big, we'll have to make it separate endpoints to serve this on demand for given week only.