### PR TITLE
FIL-915 - Throw 404 on invalid report IDs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,8 @@
         "axios": "^1.8.4",
         "axios-better-stacktrace": "^2.1.7",
         "cache-manager": "^5.7.6",
+        "class-transformer": "^0.5.1",
+        "class-validator": "^0.14.2",
         "compression": "^1.7.4",
         "lodash": "^4.17.21",
         "luxon": "^3.5.0",
@@ -3678,6 +3680,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/validator": {
+      "version": "13.15.2",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.2.tgz",
+      "integrity": "sha512-y7pa/oEJJ4iGYBxOpfAKn5b9+xuihvzDVnC/OSvlVnGxVg0pOqmjiMafiJ1KVNQEaPZf9HsEp5icEwGg8uIe5Q==",
+      "license": "MIT"
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
@@ -5047,6 +5055,23 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.1.tgz",
       "integrity": "sha512-cuSVIHi9/9E/+821Qjdvngor+xpnlwnuwIyZOaLmHBVdXL+gP+I6QQB9VkO7RI77YIcTV+S1W9AreJ5eN63JBA=="
+    },
+    "node_modules/class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
+      "license": "MIT"
+    },
+    "node_modules/class-validator": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.2.tgz",
+      "integrity": "sha512-3kMVRF2io8N8pY1IFIXlho9r8IPUUIfHe2hYVtiebvAzU2XeQFXTv+XI4WX+TnXmtwXMDcjngcpkiPM0O9PvLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/validator": "^13.11.8",
+        "libphonenumber-js": "^1.11.1",
+        "validator": "^13.9.0"
+      }
     },
     "node_modules/clean-stack": {
       "version": "2.2.0",
@@ -8365,6 +8390,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/libphonenumber-js": {
+      "version": "1.12.9",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.12.9.tgz",
+      "integrity": "sha512-VWwAdNeJgN7jFOD+wN4qx83DTPMVPPAUyx9/TUkBXKLiNkuWWk6anV0439tgdtwaJDrEdqkvdN22iA6J4bUCZg==",
+      "license": "MIT"
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
@@ -11772,6 +11803,15 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.15.15",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.15.tgz",
+      "integrity": "sha512-BgWVbCI72aIQy937xbawcs+hrVaN/CZ2UwutgaJ36hGqRrLNM+f5LUT/YPRbo8IV/ASeFzXszezV+y2+rq3l8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/varint": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "axios": "^1.8.4",
     "axios-better-stacktrace": "^2.1.7",
     "cache-manager": "^5.7.6",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.2",
     "compression": "^1.7.4",
     "lodash": "^4.17.21",
     "luxon": "^3.5.0",

--- a/src/controller/allocator-report/allocator-report.controller.ts
+++ b/src/controller/allocator-report/allocator-report.controller.ts
@@ -1,10 +1,12 @@
 import {
   Controller,
   Get,
+  HttpStatus,
   Inject,
   Logger,
   NotFoundException,
   Param,
+  ParseUUIDPipe,
   Post,
 } from '@nestjs/common';
 import {
@@ -22,7 +24,7 @@ export class AllocatorReportController {
   constructor(
     private readonly allocatorReportService: AllocatorReportService,
     @Inject(CACHE_MANAGER) private cacheManager: Cache,
-  ) {}
+  ) { }
 
   @Get(':allocator')
   @ApiOperation({
@@ -62,7 +64,11 @@ export class AllocatorReportController {
   })
   public async getAllocatorReportById(
     @Param('allocator') allocator: string,
-    @Param('id') id: string,
+    @Param('id',
+      new ParseUUIDPipe({
+        errorHttpStatusCode: HttpStatus.NOT_FOUND,
+      }),
+    ) id: string,
   ) {
     const report = await this.allocatorReportService.getReport(allocator, id);
 

--- a/src/controller/client-report/client-report.controller.ts
+++ b/src/controller/client-report/client-report.controller.ts
@@ -2,10 +2,12 @@ import {
   Body,
   Controller,
   Get,
+  HttpStatus,
   Inject,
   Logger,
   NotFoundException,
   Param,
+  ParseIntPipe,
   Post,
 } from '@nestjs/common';
 import { ClientReportService } from 'src/service/client-report/client-report.service';
@@ -26,7 +28,7 @@ export class ClientReportController {
     private readonly clientReportsService: ClientReportService,
     @Inject(CACHE_MANAGER) private cacheManager: Cache,
     private readonly gitHubTriggersHandlerService: GitHubTriggersHandlerService,
-  ) {}
+  ) { }
 
   @Post('/gh-trigger')
   @ApiExcludeEndpoint()
@@ -72,7 +74,13 @@ export class ClientReportController {
   })
   public async getClientReportById(
     @Param('client') client: string,
-    @Param('id') id: bigint,
+    @Param(
+      'id',
+      new ParseIntPipe({
+        errorHttpStatusCode: HttpStatus.NOT_FOUND,
+      }),
+    )
+    id: bigint,
   ) {
     const report = await this.clientReportsService.getReport(client, id);
 


### PR DESCRIPTION
These 2 are throwing 500 internal server errors when invalid format of report ID is used:
* https://cdp.allocator.tech/client-report/f03359919/asd
* https://cdp.allocator.tech/allocator-report/f03359919/asd

This PR adds validation that throws 404 in such cases instead.

Deployed to staging:
* https://cdp.staging.allocator.tech/client-report/f03359919/asd
* https://cdp.staging.allocator.tech/allocator-report/f03359919/asd