### PR TITLE
FIL-187 - Unused DC check in client report

### DIFF
--- a/prisma/migrations/20250627122639_dc_tracking_in_client_reports/migration.sql
+++ b/prisma/migrations/20250627122639_dc_tracking_in_client_reports/migration.sql
@@ -1,0 +1,7 @@
+-- AlterEnum
+ALTER TYPE "ClientReportCheck" ADD VALUE 'INACTIVITY';
+
+-- AlterTable
+ALTER TABLE "client_report" ADD COLUMN     "available_datacap" BIGINT,
+ADD COLUMN     "last_datacap_received" TIMESTAMP(3),
+ADD COLUMN     "last_datacap_spent" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -202,6 +202,9 @@ model client_report {
   using_client_contract         Boolean?
   client_contract_max_deviation String?
   storage_provider_ids_declared String[]                                      @default([])
+  available_datacap             BigInt?
+  last_datacap_spent            DateTime?
+  last_datacap_received         DateTime?
 }
 
 enum StorageProviderIpniReportingStatus {
@@ -450,6 +453,7 @@ enum ClientReportCheck {
   DEAL_DATA_REPLICATION_CID_SHARING
   MULTIPLE_ALLOCATORS
   NOT_ENOUGH_COPIES
+  INACTIVITY
 }
 
 enum AllocatorReportCheck {

--- a/src/controller/allocator-report/allocator-report.controller.ts
+++ b/src/controller/allocator-report/allocator-report.controller.ts
@@ -24,7 +24,7 @@ export class AllocatorReportController {
   constructor(
     private readonly allocatorReportService: AllocatorReportService,
     @Inject(CACHE_MANAGER) private cacheManager: Cache,
-  ) { }
+  ) {}
 
   @Get(':allocator')
   @ApiOperation({
@@ -64,11 +64,13 @@ export class AllocatorReportController {
   })
   public async getAllocatorReportById(
     @Param('allocator') allocator: string,
-    @Param('id',
+    @Param(
+      'id',
       new ParseUUIDPipe({
         errorHttpStatusCode: HttpStatus.NOT_FOUND,
       }),
-    ) id: string,
+    )
+    id: string,
   ) {
     const report = await this.allocatorReportService.getReport(allocator, id);
 

--- a/src/controller/client-report/client-report.controller.ts
+++ b/src/controller/client-report/client-report.controller.ts
@@ -28,7 +28,7 @@ export class ClientReportController {
     private readonly clientReportsService: ClientReportService,
     @Inject(CACHE_MANAGER) private cacheManager: Cache,
     private readonly gitHubTriggersHandlerService: GitHubTriggersHandlerService,
-  ) { }
+  ) {}
 
   @Post('/gh-trigger')
   @ApiExcludeEndpoint()

--- a/src/service/client-report/client-report.service.ts
+++ b/src/service/client-report/client-report.service.ts
@@ -6,6 +6,7 @@ import { ClientService } from '../client/client.service';
 import { GlifAutoVerifiedAllocatorId } from 'src/utils/constants';
 import { AllocatorService } from '../allocator/allocator.service';
 import { EthApiService } from '../eth-api/eth-api.service';
+import { LotusApiService } from '../lotus-api/lotus-api.service';
 
 @Injectable()
 export class ClientReportService {
@@ -16,6 +17,7 @@ export class ClientReportService {
     private readonly clientService: ClientService,
     private readonly allocatorService: AllocatorService,
     private readonly ethApiService: EthApiService,
+    private readonly lotusApiService: LotusApiService,
   ) {}
 
   public async generateReport(clientIdOrAddress: string, returnFull = false) {
@@ -59,6 +61,16 @@ export class ClientReportService {
         )
       : null;
 
+    const availableDatacap = await this.lotusApiService.getClientDatacap(
+      clientData[0].addressId,
+    );
+    const lastDatacapSpent = await this.clientService.getLastDatacapSpent(
+      clientData[0].addressId,
+    );
+    const lastDatacapReceived = await this.clientService.getLastDatacapReceived(
+      clientData[0].addressId,
+    );
+
     const report = await this.prismaService.client_report.create({
       data: {
         client: clientData[0].addressId,
@@ -78,6 +90,9 @@ export class ClientReportService {
         storage_provider_ids_declared:
           bookkeepingInfo?.storageProviderIDsDeclared,
         client_contract_max_deviation: maxDeviation,
+        available_datacap: availableDatacap,
+        last_datacap_spent: lastDatacapSpent,
+        last_datacap_received: lastDatacapReceived,
         storage_provider_distribution: {
           create:
             storageProviderDistribution?.map((provider) => {

--- a/src/service/client/client.service.ts
+++ b/src/service/client/client.service.ts
@@ -24,6 +24,50 @@ export class ClientService {
     @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
   ) {}
 
+  public async getLastDatacapSpent(clientId: string): Promise<Date | null> {
+    const result =
+      await this.prismaService.unified_verified_deal_hourly.findFirst({
+        select: {
+          hour: true,
+        },
+        where: {
+          OR: [
+            {
+              client: clientId,
+            },
+          ],
+        },
+        orderBy: {
+          hour: 'desc',
+        },
+      });
+
+    return result?.hour;
+  }
+
+  public async getLastDatacapReceived(clientId: string): Promise<Date | null> {
+    const result =
+      await this.prismaDmobService.verified_client_allowance.findFirst({
+        select: {
+          createMessageTimestamp: true,
+        },
+        where: {
+          OR: [
+            {
+              addressId: clientId,
+            },
+          ],
+        },
+        orderBy: {
+          createMessageTimestamp: 'desc',
+        },
+      });
+
+    if (!result || !result.createMessageTimestamp) return null;
+
+    return new Date(result.createMessageTimestamp * 1000);
+  }
+
   public getClientApplicationUrl(clientData?: {
     allowanceArray: {
       auditTrail: string | null;

--- a/src/service/lotus-api/lotus-api.service.ts
+++ b/src/service/lotus-api/lotus-api.service.ts
@@ -2,6 +2,7 @@ import { Inject, Injectable, Logger } from '@nestjs/common';
 import {
   LotusStateLookupIdResponse,
   LotusStateMinerInfoResponse,
+  LotusStateVerifiedClientStatusResponse,
 } from './types.lotus-api';
 import { firstValueFrom } from 'rxjs';
 import { HttpService } from '@nestjs/axios';
@@ -98,5 +99,21 @@ export class LotusApiService {
     if (!data?.result) throw new Error(`No data`);
 
     return data;
+  }
+
+  public async getClientDatacap(address: string): Promise<bigint | null> {
+    const endpoint = `${this.configService.get<string>('GLIF_API_BASE_URL')}/v1`;
+    const { data } = await firstValueFrom(
+      this.httpService.post<LotusStateVerifiedClientStatusResponse>(endpoint, {
+        jsonrpc: '2.0',
+        method: 'Filecoin.StateVerifiedClientStatus',
+        params: [address, []],
+        id: 0,
+      }),
+    );
+
+    if (data.error || !data.result) return null;
+
+    return BigInt(data.result);
   }
 }

--- a/src/service/lotus-api/types.lotus-api.ts
+++ b/src/service/lotus-api/types.lotus-api.ts
@@ -1,5 +1,12 @@
 // noinspection SpellCheckingInspection,JSUnusedGlobalSymbols
 
+export interface LotusStateVerifiedClientStatusResponse {
+  jsonrpc: string;
+  result?: string;
+  error?: LotusError;
+  id: number;
+}
+
 export interface LotusStateMinerInfoResponse {
   jsonrpc: string;
   result: LotusStateMinerInfoResult;


### PR DESCRIPTION
This PR adds a new check in client reports that should trigger if all of these conditions are met:
* client last received datacap more than a month ago
* client didn't spent all of this datacap
* client didn't spent any datacap for at least a month.

a.k.a. we want to find clients that are inactive, but still hold some DC.