### PR TITLE
fix(po-rep): properly calculate cumulative USD history values

### DIFF
--- a/prisma/sql/getFilecoinPaymentsForDealsHistory.sql
+++ b/prisma/sql/getFilecoinPaymentsForDealsHistory.sql
@@ -17,7 +17,7 @@ WITH truncated_payments AS (
             )
         )::DATE AS window_start,
         r.token as token_address,
-        SUM(p."netPayeeAmount") AS window_amount
+        SUM(p."netPayeeAmount") AS window_total
     FROM filecoin_pay_payment p
     INNER JOIN filecoin_pay_rail r
         ON r."railId" = p."railId"
@@ -32,11 +32,6 @@ WITH truncated_payments AS (
 SELECT
     window_start,
     token_address,
-    window_amount,
-    SUM(window_amount) OVER (
-        PARTITION BY token_address
-        ORDER BY window_start
-        ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
-    ) AS cumulative_amount
+    window_total
 FROM truncated_payments
 ORDER BY window_start;

--- a/prisma/sql/getPoRepDealsValueHistory.sql
+++ b/prisma/sql/getPoRepDealsValueHistory.sql
@@ -52,11 +52,6 @@ window_totals AS (
 SELECT
     window_start,
     token_address,
-    window_total,
-    SUM(window_total) OVER (
-        PARTITION BY token_address
-        ORDER BY window_start
-        ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
-    ) AS cumulative_amount
+    window_total
 FROM window_totals
 ORDER BY window_start;

--- a/prisma/sql/getPoRepSLIComplianceHistory.sql
+++ b/prisma/sql/getPoRepSLIComplianceHistory.sql
@@ -97,8 +97,6 @@ average_measurements AS (
         ON mv.provider = 'f0' || psp."providerId"
     LEFT JOIN storage_provider_url_finder_metric metric
         ON metric.id = mv.metric_id
-    LEFT JOIN po_rep_storage_provider_capabilities pspc
-        ON pspc."providerId" = psp."providerId"
     WHERE tested_at >= b.start_window
         AND (
             ($3::TEXT IS NULL AND metric_type IN (

--- a/src/controller/po-rep/po-rep.controller.ts
+++ b/src/controller/po-rep/po-rep.controller.ts
@@ -13,26 +13,27 @@ import {
   ApiOkResponse,
   ApiOperation,
 } from '@nestjs/swagger';
-import { groupBy } from 'lodash';
 import { DateTime } from 'luxon';
 import {
   PoRepDealState,
   Prisma,
   StorageProviderUrlFinderMetricType,
 } from 'prisma/generated/client';
-import { Decimal } from 'prisma/generated/client/runtime/index-browser';
 import { PrismaService } from 'src/db/prisma.service';
+import { PoRepService } from 'src/service/po-rep/po-rep.service';
 import {
-  PoRepService,
-  SLIComplianceHistoryParameters,
-} from 'src/service/po-rep/po-rep.service';
-import {
-  bigIntDiv,
-  BigIntString,
-  F0Id,
-  safeDiv,
-  stringToBool,
-} from 'src/utils/utils';
+  PoRepActiveClientsHistoryEntry,
+  PoRepActiveClientsHistoryParameters,
+  PoRepDealsPaymentsHistoryEntry,
+  PoRepDealsValueHistoryEntry,
+  PoRepHistoryParameters,
+  PoRepOnboardedDataHistoryEntry,
+  PoRepSLIComplianceHistoryEntry,
+  PoRepSLIComplianceHistoryParameters,
+  PoRepSLIType,
+  poRepSLITypes,
+} from 'src/service/po-rep/types.po-rep';
+import { bigIntDiv, BigIntString, F0Id, stringToBool } from 'src/utils/utils';
 import { ControllerBase } from '../base/controller-base';
 import {
   DashboardStatistic,
@@ -41,21 +42,11 @@ import {
 import {
   GetPoRepProvidersResponse,
   GetPoRepStatisticsRequest,
-  PoRepActiveClientsHistoryEntry,
-  PoRepActiveClientsHistoryParameters,
   PoRepDashboardStatistic,
   PoRepDashboardStatisticType,
-  PoRepDealsPaymentsHistoryEntry,
-  PoRepDealsValueHistoryEntry,
-  PoRepHistoryRequest,
-  PoRepOnboardedDataHistoryEntry,
   PoRepProviderSLIInfo,
   PoRepProvidersListParameters,
-  PoRepSLIComplianceHistoryEntry,
-  PoRepSLIComplianceHistoryParameters,
   PoRepSLIMeasurment,
-  PoRepSLIType,
-  poRepSLITypes,
 } from './types.po-rep';
 
 const sliTypesMap: Record<
@@ -130,9 +121,11 @@ export class PoRepController extends ControllerBase {
     ] = await Promise.all([
       this.poRepService.getDealsDoneCountUpToDate(),
       this.poRepService.getDealsDoneCountUpToDate(cutoffDate.toJSDate()),
-      this.poRepService.getOnboardedDataHistory(interval),
-      this.poRepService.getDealsValueHistory(interval),
-      this.poRepService.getDealsPaymentsSummaryHistory(interval),
+      this.poRepService.getOnboardedDataHistory({ windowSize: interval }),
+      this.poRepService.getDealsValueHistory({ windowSize: interval }),
+      this.poRepService.getDealsPaymentsSummaryHistory({
+        windowSize: interval,
+      }),
       this.poRepService.getActiveClientsHistory({ windowSize: interval }),
     ]);
 
@@ -202,11 +195,11 @@ export class PoRepController extends ControllerBase {
         type: 'ACTIVE_CLIENTS_COUNT',
         interval: interval,
         currentValue: {
-          value: currentActiveClientsEntry?.active_clients_count ?? 0,
+          value: currentActiveClientsEntry?.activeClientsCount ?? 0,
           type: 'numeric',
         },
         previousValue: {
-          value: comparedActiveClientsEntry?.active_clients_count ?? 0,
+          value: comparedActiveClientsEntry?.activeClientsCount ?? 0,
           type: 'numeric',
         },
       }),
@@ -375,18 +368,9 @@ export class PoRepController extends ControllerBase {
   })
   @CacheTTL(1000 * 60 * 30) // 30 minutes
   public async getOnboardedDataHistory(
-    @Query(new ValidationPipe()) query: PoRepHistoryRequest,
+    @Query(new ValidationPipe()) query: PoRepHistoryParameters,
   ): Promise<PoRepOnboardedDataHistoryEntry[]> {
-    const { windowSize = 'day' } = query;
-    const results = await this.poRepService.getOnboardedDataHistory(windowSize);
-
-    return results.map<PoRepOnboardedDataHistoryEntry>((result) => {
-      return {
-        date: result.date.toFormat('yyyy-MM-dd'),
-        volume: result.volume.toString(),
-        cumulativeTotal: result.cumulativeTotal.toString(),
-      };
-    });
+    return this.poRepService.getOnboardedDataHistory(query);
   }
 
   @Get('/deals-value-history')
@@ -398,18 +382,9 @@ export class PoRepController extends ControllerBase {
   })
   @CacheTTL(1000 * 60 * 30) // 30 minutes
   public async getDealsValueHistory(
-    @Query(new ValidationPipe()) query: PoRepHistoryRequest,
+    @Query(new ValidationPipe()) query: PoRepHistoryParameters,
   ): Promise<PoRepDealsValueHistoryEntry[]> {
-    const { windowSize = 'day' } = query;
-    const results = await this.poRepService.getDealsValueHistory(windowSize);
-
-    return results.map<PoRepDealsValueHistoryEntry>((result) => {
-      return {
-        date: result.date.toFormat('yyyy-MM-dd'),
-        volumeUSD: result.volumeUSD,
-        cumulativeTotalUSD: result.cumulativeTotalUSD,
-      };
-    });
+    return this.poRepService.getDealsValueHistory(query);
   }
 
   @Get('/payments-history')
@@ -422,19 +397,9 @@ export class PoRepController extends ControllerBase {
   })
   @CacheTTL(1000 * 60 * 30) // 30 minutes
   public async getPaymentsHistory(
-    @Query(new ValidationPipe()) query: PoRepHistoryRequest,
+    @Query(new ValidationPipe()) query: PoRepHistoryParameters,
   ): Promise<PoRepDealsPaymentsHistoryEntry[]> {
-    const { windowSize = 'day' } = query;
-    const results =
-      await this.poRepService.getDealsPaymentsSummaryHistory(windowSize);
-
-    return results.map((result) => {
-      return {
-        date: result.date.toFormat('yyyy-MM-dd'),
-        dailyAmountUSD: result.volumeUSD,
-        cumulativeAmountUSD: result.cumulativeTotalUSD,
-      };
-    });
+    return this.poRepService.getDealsPaymentsSummaryHistory(query);
   }
 
   @Get('/sli-compliance-history')
@@ -454,91 +419,7 @@ export class PoRepController extends ControllerBase {
   public async getSLIComplianceHistory(
     @Query(new ValidationPipe()) query: PoRepSLIComplianceHistoryParameters,
   ): Promise<PoRepSLIComplianceHistoryEntry[]> {
-    const { windowSize = 'day', sliType, providerId, dealId } = query;
-    const results = await this.poRepService.getSLIComplianceHistory({
-      windowSize: windowSize,
-      sliType: this.mapSLIType(sliType),
-      providerId: providerId ? BigInt(providerId) : null,
-      dealId: dealId ? BigInt(dealId) : null,
-    });
-
-    const grouped = groupBy(results, (result) =>
-      result.window_start.toISOString(),
-    );
-
-    const states = [
-      'compliant',
-      'nonCompliant',
-      'unknown',
-    ] as const satisfies Omit<keyof PoRepSLIComplianceHistoryEntry, 'date'>[];
-
-    return Object.entries(grouped)
-      .slice(0, -1)
-      .map<PoRepSLIComplianceHistoryEntry>(([dateISOString, results]) => {
-        const [totalProvidersCount, totalDealsCount, totalDealsSize] =
-          results.reduce(
-            (totals, result) => {
-              return [
-                totals[0] + result.providers_count,
-                totals[1] + result.deals_count,
-                totals[2].add(result.total_deals_size),
-              ];
-            },
-            [0, 0, Decimal(0)],
-          );
-
-        const stateEntries = states.map((state) => {
-          const stateResult = results.find(
-            (c) => c.compliance_state.toLowerCase() === state.toLowerCase(),
-          );
-
-          if (!stateResult) {
-            return [
-              state,
-              {
-                providersCount: 0,
-                providersPercentage: 0,
-                dealsCount: 0,
-                dealsPercentage: 0,
-                totalDealsSize: '0',
-                totalDealsSizePercentage: 0,
-              },
-            ];
-          }
-
-          return [
-            state,
-            {
-              providersCount: stateResult.providers_count,
-              providersPercentage: safeDiv(
-                stateResult.providers_count,
-                totalProvidersCount,
-                0,
-              ),
-              dealsCount: stateResult.deals_count,
-              dealsPercentage: safeDiv(
-                stateResult.deals_count,
-                totalDealsCount,
-                0,
-              ),
-              totalDealsSize: stateResult.total_deals_size.toString(),
-              totalDealsSizePercentage: totalDealsSize.eq(0)
-                ? 0
-                : stateResult.total_deals_size.div(totalDealsSize).toNumber(),
-            },
-          ] as const;
-        });
-
-        return {
-          date: DateTime.fromISO(dateISOString, { zone: 'UTC' }).toFormat(
-            'yyyy-MM-dd',
-          ),
-          ...(Object.fromEntries(stateEntries) as Omit<
-            PoRepSLIComplianceHistoryEntry,
-            'date'
-          >),
-        };
-      });
+    return this.poRepService.getSLIComplianceHistory(query);
   }
 
   @Get('/active-clients-history')
@@ -561,8 +442,10 @@ export class PoRepController extends ControllerBase {
   public async getActiveClientsHistory(
     @Query(new ValidationPipe()) query: PoRepActiveClientsHistoryParameters,
   ): Promise<PoRepActiveClientsHistoryEntry[]> {
-    const { windowSize = 'day' } = query;
-    const providerId = query.providerId ? F0Id.from(query.providerId) : null;
+    const providerId =
+      query.providerId !== null && query.providerId !== undefined
+        ? F0Id.from(query.providerId)
+        : null;
 
     if (providerId) {
       const provider =
@@ -579,19 +462,7 @@ export class PoRepController extends ControllerBase {
       }
     }
 
-    const results = await this.poRepService.getActiveClientsHistory({
-      windowSize,
-      providerId,
-    });
-
-    return results.map((result) => {
-      return {
-        date: DateTime.fromJSDate(result.window_start, {
-          zone: 'UTC',
-        }).toFormat('yyyy-MM-dd'),
-        activeClientsCount: result.active_clients_count,
-      };
-    });
+    return this.poRepService.getActiveClientsHistory(query);
   }
 
   private calculateDashboardStatistic(options: {
@@ -639,20 +510,5 @@ export class PoRepController extends ControllerBase {
       value: currentValue,
       percentageChange: percentageChange,
     };
-  }
-
-  private mapSLIType(
-    poRepSLIType: PoRepSLIType | undefined,
-  ): SLIComplianceHistoryParameters['sliType'] {
-    switch (poRepSLIType) {
-      case 'bandwidthMbps':
-        return 'BANDWIDTH';
-      case 'indexingPct':
-        return null; // Not measured
-      case 'latencyMs':
-        return 'TTFB';
-      case 'retrievabilityBps':
-        return 'RPA_RETRIEVABILITY';
-    }
   }
 }

--- a/src/controller/po-rep/types.po-rep.ts
+++ b/src/controller/po-rep/types.po-rep.ts
@@ -1,26 +1,13 @@
-import {
-  ApiProperty,
-  ApiPropertyOptional,
-  PartialType,
-  PickType,
-} from '@nestjs/swagger';
-import { IsBooleanString, IsIn, IsOptional } from 'class-validator';
-import { F0IdInput, IsBigIntLike, IsF0IdInput } from 'src/utils/validators';
+import { ApiProperty, PartialType, PickType } from '@nestjs/swagger';
+import { IsBooleanString, IsOptional } from 'class-validator';
+import { PoRepSLIType, poRepSLITypes } from 'src/service/po-rep/types.po-rep';
+import { F0IdInput, IsF0IdInput } from 'src/utils/validators';
 import {
   DashboardStatistic,
   DashboardStatisticChange,
   PaginationInfoRequest,
   PaginationInfoResponse,
 } from '../base/types.controller-base';
-
-export type PoRepSLIType = (typeof poRepSLITypes)[number];
-
-export const poRepSLITypes = [
-  'retrievabilityBps',
-  'bandwidthMbps',
-  'latencyMs',
-  'indexingPct',
-] as const;
 
 export const poRepDashboardStatisticTypes = [
   'TOTAL_DEALS_DONE',
@@ -124,59 +111,6 @@ export class PoRepProviderInfo {
   registeredAtBlock: string;
 }
 
-export class PoRepOnboardedDataHistoryEntry {
-  @ApiProperty({
-    description: 'Entry date',
-  })
-  date: string;
-
-  @ApiProperty({
-    description: 'Entry volume of onboarded data in bytes',
-  })
-  volume: string;
-
-  @ApiProperty({
-    description:
-      'Cumulative amount of onboarded data in bytes, up to the entry date',
-  })
-  cumulativeTotal: string;
-}
-
-export class PoRepDealsValueHistoryEntry {
-  @ApiProperty({
-    description: 'Entry date',
-  })
-  date: string;
-
-  @ApiProperty({
-    description: 'Total value of deals accepted in entry window in USD',
-  })
-  volumeUSD: number;
-
-  @ApiProperty({
-    description:
-      'Cumulative total value of accepted deals in USD, up to entry date',
-  })
-  cumulativeTotalUSD: number;
-}
-
-export class PoRepDealsPaymentsHistoryEntry {
-  @ApiProperty({
-    description: 'Entry date',
-  })
-  date: string;
-
-  @ApiProperty({
-    description: 'Daily volume of payments in USD',
-  })
-  dailyAmountUSD: number;
-
-  @ApiProperty({
-    description: 'Cumulative amount of payments in USD up to the entry date',
-  })
-  cumulativeAmountUSD: number;
-}
-
 export type PoRepDashboardStatisticType =
   (typeof poRepDashboardStatisticTypes)[number];
 
@@ -192,20 +126,6 @@ export class PoRepDashboardStatistic extends DashboardStatistic {
 export class GetPoRepStatisticsRequest extends PartialType(
   PickType(DashboardStatisticChange, ['interval'] as const),
 ) {}
-
-const poRepHistoryWindowSize = ['day', 'week', 'month'] as const;
-export class PoRepHistoryRequest {
-  @ApiProperty({
-    description: 'Window size of returned data, eg. "week"',
-    enum: poRepHistoryWindowSize,
-    enumName: 'PoRepHistoryWindowSize',
-    required: false,
-    default: 'day',
-  })
-  @IsOptional()
-  @IsIn(poRepHistoryWindowSize)
-  windowSize?: (typeof poRepHistoryWindowSize)[number];
-}
 
 export class PoRepProvidersListParameters extends PaginationInfoRequest {
   @ApiProperty({
@@ -235,137 +155,4 @@ export class GetPoRepProvidersResponse extends PaginationInfoResponse {
     isArray: true,
   })
   data: PoRepProviderInfo[];
-}
-
-export class PoRepSLIComplianceHistoryParameters {
-  @ApiPropertyOptional({
-    description: 'History window interval, default is one day window',
-    enum: poRepHistoryWindowSize,
-    enumName: 'PoRepHistoryWindowSize',
-    required: false,
-    default: 'day',
-  })
-  @IsOptional()
-  @IsIn(poRepHistoryWindowSize)
-  windowSize?: 'day' | 'week' | 'month';
-
-  @ApiPropertyOptional({
-    description: 'SLI type to filter by, leave empty to include all',
-    required: false,
-    enum: poRepSLITypes,
-    enumName: 'PoREpSLIType',
-  })
-  @IsOptional()
-  @IsIn(poRepSLITypes)
-  sliType?: PoRepSLIType;
-
-  @ApiPropertyOptional({
-    description: 'Provider ID to filter by, no filter by default',
-    required: false,
-  })
-  @IsOptional()
-  @IsBigIntLike()
-  providerId?: string;
-
-  @ApiPropertyOptional({
-    description: 'Deal ID to filter by, no filter by default',
-    required: false,
-  })
-  @IsOptional()
-  @IsBigIntLike()
-  dealId?: string;
-}
-
-export class PoRepSLIComplianceHistoryStateValues {
-  @ApiProperty({
-    description:
-      'Number of providers having at least one deal matching given state',
-  })
-  providersCount: number;
-
-  @ApiProperty({
-    description:
-      'Percentage of providers having at least one deal matching given state',
-  })
-  providersPercentage: number;
-
-  @ApiProperty({
-    description: 'Number of deals matching given state',
-  })
-  dealsCount: number;
-
-  @ApiProperty({
-    description: 'Percentage of deals matching given state',
-  })
-  dealsPercentage: number;
-
-  @ApiProperty({
-    description: 'Total size of deals matching given state in bytes',
-  })
-  totalDealsSize: string;
-
-  @ApiProperty({
-    description: 'Percentage of deals size matching given state',
-  })
-  totalDealsSizePercentage: number;
-}
-
-export class PoRepSLIComplianceHistoryEntry {
-  @ApiProperty({
-    description: 'Window start ISO date (UTC)',
-  })
-  date: string;
-
-  @ApiProperty({
-    description:
-      'Values for compliant deals. Compliant deals are those for which all selected SLIs were met in given window.',
-  })
-  compliant: PoRepSLIComplianceHistoryStateValues;
-
-  @ApiProperty({
-    description:
-      'Values for non-compliant deals. Non-compliant deals are those for which any of the selected SLIs were not met in given window.',
-  })
-  nonCompliant: PoRepSLIComplianceHistoryStateValues;
-
-  @ApiProperty({
-    description:
-      'Values for unknown state deals. Unknown deals are those for which any of the selected SLIs were not measured at least once in given window.',
-  })
-  unknown: PoRepSLIComplianceHistoryStateValues;
-}
-
-export class PoRepActiveClientsHistoryParameters {
-  @ApiPropertyOptional({
-    description: 'History window interval, default is one day window',
-    enum: poRepHistoryWindowSize,
-    enumName: 'PoRepHistoryWindowSize',
-    required: false,
-    default: 'day',
-  })
-  @IsOptional()
-  @IsIn(poRepHistoryWindowSize)
-  windowSize?: 'day' | 'week' | 'month';
-
-  @ApiPropertyOptional({
-    description: 'Provider ID to filter by, no filter by default',
-    required: false,
-    type: 'string',
-  })
-  @IsOptional()
-  @IsF0IdInput()
-  providerId?: F0IdInput;
-}
-
-export class PoRepActiveClientsHistoryEntry {
-  @ApiProperty({
-    description: 'Entry date',
-  })
-  date: string;
-
-  @ApiProperty({
-    description:
-      'Count of active clients in a window. Client is considered active if they have at least one deal completed before or during the window, that was not terminated before window start.',
-  })
-  activeClientsCount: number;
 }

--- a/src/service/po-rep/po-rep.service.ts
+++ b/src/service/po-rep/po-rep.service.ts
@@ -428,16 +428,17 @@ export class PoRepService {
 
   private mapSLIType(
     poRepSLIType: PoRepSLIType | undefined,
-  ): StorageProviderUrlFinderMetricType {
+  ): StorageProviderUrlFinderMetricType | null {
     switch (poRepSLIType) {
       case 'bandwidthMbps':
         return StorageProviderUrlFinderMetricType.BANDWIDTH;
-      case 'indexingPct':
-        return null; // Not measured
       case 'latencyMs':
         return StorageProviderUrlFinderMetricType.TTFB;
       case 'retrievabilityBps':
         return StorageProviderUrlFinderMetricType.RPA_RETRIEVABILITY;
+      case 'indexingPct':
+      default:
+        return null;
     }
   }
 }

--- a/src/service/po-rep/po-rep.service.ts
+++ b/src/service/po-rep/po-rep.service.ts
@@ -1,6 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { groupBy, uniq } from 'lodash';
 import { DateTime } from 'luxon';
+import { StorageProviderUrlFinderMetricType } from 'prisma/generated/client';
 import { Decimal } from 'prisma/generated/client/runtime/library';
 import {
   getFilecoinPaymentsForDealsHistory,
@@ -15,50 +16,22 @@ import {
   dateToFilecoinBlockHeight,
   F0Id,
   filecoinBlockHeightToDate,
+  safeDiv,
 } from 'src/utils/utils';
-import { F0IdInput } from 'src/utils/validators';
 import { filecoinCalibration } from 'viem/chains';
 import { ERC20TokenInfoService } from '../erc20-token-info/erc20-token-info.service';
 import { PoRepPriceOracleService } from '../po-rep-price-oracle/po-rep-price-oracle.service';
-
-type WindowSize = 'day' | 'week' | 'month';
-
-export interface SLIComplianceHistoryParameters {
-  windowSize: WindowSize;
-  sliType: 'RPA_RETRIEVABILITY' | 'BANDWIDTH' | 'TTFB' | null;
-  providerId: bigint | null;
-  dealId: bigint | null;
-}
-
-export interface ActiveClientsHistoryParameters {
-  windowSize: WindowSize;
-  providerId?: F0Id | F0IdInput | null;
-}
-
-export interface PoRepDealsPaymentsSummaryHistoryEntry {
-  date: DateTime;
-  volumeUSD: number;
-  cumulativeTotalUSD: number;
-}
-
-export type PoRepDealsPaymentsSummaryHistory =
-  PoRepDealsPaymentsSummaryHistoryEntry[];
-
-export interface PoRepOnboardedDataHistoryEntry {
-  date: DateTime;
-  volume: bigint;
-  cumulativeTotal: bigint;
-}
-
-export type PoRepDealsOnboardedDataHistory = PoRepOnboardedDataHistoryEntry[];
-
-export interface PoRepDealsValueHistoryEntry {
-  date: DateTime;
-  volumeUSD: number;
-  cumulativeTotalUSD: number;
-}
-
-export type PoRepDealsValueHistory = PoRepDealsValueHistoryEntry[];
+import {
+  PoRepActiveClientsHistoryEntry,
+  PoRepActiveClientsHistoryParameters,
+  PoRepDealsPaymentsHistoryEntry,
+  PoRepDealsValueHistoryEntry,
+  PoRepHistoryParameters,
+  PoRepOnboardedDataHistoryEntry,
+  PoRepSLIComplianceHistoryEntry,
+  PoRepSLIComplianceHistoryParameters,
+  PoRepSLIType,
+} from './types.po-rep';
 
 @Injectable()
 export class PoRepService {
@@ -70,9 +43,9 @@ export class PoRepService {
     private readonly recentNodeClient: PoRepPublicClient,
   ) {}
 
-  public async getDealsPaymentsSummaryHistory(
-    windowSize: WindowSize,
-  ): Promise<PoRepDealsPaymentsSummaryHistory> {
+  public async getDealsPaymentsSummaryHistory({
+    windowSize = 'day',
+  }: PoRepHistoryParameters): Promise<PoRepDealsPaymentsHistoryEntry[]> {
     const earliestDeal = await this.prismaService.po_rep_deal.findFirst({
       orderBy: {
         proposedAtBlock: 'asc',
@@ -134,75 +107,49 @@ export class PoRepService {
       });
     }, new Map<string, Token>());
 
-    const dataByDate = groupBy(
+    const dataByWindow = groupBy(
       data.filter((item) => item.window_start !== null),
-      (item) => item.window_start.toISOString(),
+      (item) => DateTime.fromJSDate(item.window_start).toISODate(),
     );
 
-    // DB query returns window data per token so we need to convert values in
-    // token units to USD and sum them for each window
-    const combinedWindowData = Object.entries(
-      dataByDate,
-    ).map<PoRepDealsPaymentsSummaryHistoryEntry>(
-      ([dateISOString, perDateResults]) => {
-        const [windowAmountUSD, cumulativeAmountUSD] = perDateResults.reduce(
-          ([currentDailyAmountUSD, currentCumulativeAmountUSD], result) => {
-            const tokenUSDExchangeRate = tokensUSDExchangeRates.get(
-              result.token_address,
+    return [...new Array(entriesCount)].reduce<
+      PoRepDealsPaymentsHistoryEntry[]
+    >((result, _, index) => {
+      const entryDate = startDate.plus({ [windowSize]: index });
+      const entryISODate = entryDate.toISODate();
+      const dataForWindow = dataByWindow[entryISODate] ?? [];
+
+      const windowVolumeUSD = dataForWindow
+        .reduce((currentWindowVolumeUSD, result) => {
+          const tokenUSDExchangeRate = tokensUSDExchangeRates.get(
+            result.token_address,
+          );
+          const tokenInfo = tokensInfo.get(result.token_address);
+
+          // Should not happen but type safety
+          if (!tokenUSDExchangeRate || !tokenInfo) {
+            throw new Error(
+              `Exchange rate or info not found for token "${result.token_address}"`,
             );
-            const tokenInfo = tokensInfo.get(result.token_address);
+          }
 
-            // Should not happen but type safety
-            if (!tokenUSDExchangeRate || !tokenInfo) {
-              throw new Error(
-                `Exchange rate or info not found for token "${result.token_address}"`,
-              );
-            }
+          const tokenExponent = Math.pow(10, tokenInfo.decimals);
+          const tokenWindowTotalUSD = result.window_total
+            .div(tokenExponent)
+            .mul(tokenUSDExchangeRate);
 
-            const tokenExponent = Math.pow(10, tokenInfo.decimals);
-            const tokenDailyAmountUSD = result.window_amount
-              .div(tokenExponent)
-              .mul(tokenUSDExchangeRate);
-            const tokenCumulativeAmountUSD = result.cumulative_amount
-              .div(tokenExponent)
-              .mul(tokenUSDExchangeRate);
-
-            return [
-              currentDailyAmountUSD.add(tokenDailyAmountUSD),
-              currentCumulativeAmountUSD.add(tokenCumulativeAmountUSD),
-            ];
-          },
-          [new Decimal(0), new Decimal(0)],
-        );
-
-        return {
-          date: DateTime.fromISO(dateISOString, { zone: 'utc' }),
-          volumeUSD: windowAmountUSD.toDecimalPlaces(2).toNumber(),
-          cumulativeTotalUSD: cumulativeAmountUSD.toDecimalPlaces(2).toNumber(),
-        };
-      },
-    );
-
-    const combinedWindowDataByISODate = new Map(
-      combinedWindowData.map((item) => [item.date.toISODate(), item]),
-    );
-
-    return [
-      ...new Array(entriesCount),
-    ].reduce<PoRepDealsPaymentsSummaryHistory>((result, _, index) => {
-      const entryDay = startDate.plus({ [windowSize]: index });
-      const entryISODate = entryDay.toISODate();
-      const matchingData = combinedWindowDataByISODate.get(entryISODate);
-
-      if (matchingData) {
-        return [...result, matchingData];
-      }
+          return currentWindowVolumeUSD.add(tokenWindowTotalUSD);
+        }, new Decimal(0))
+        .toDecimalPlaces(2)
+        .toNumber();
 
       const previousEntry = index === 0 ? undefined : result.at(index - 1);
-      const nextEntry: PoRepDealsPaymentsSummaryHistoryEntry = {
-        date: entryDay,
-        volumeUSD: 0,
-        cumulativeTotalUSD: previousEntry?.cumulativeTotalUSD ?? 0,
+      const previousTotalUSD = previousEntry?.cumulativeTotalUSD ?? 0;
+
+      const nextEntry: PoRepDealsPaymentsHistoryEntry = {
+        date: entryISODate,
+        volumeUSD: windowVolumeUSD,
+        cumulativeTotalUSD: previousTotalUSD + windowVolumeUSD,
       };
 
       return [...result, nextEntry];
@@ -226,25 +173,27 @@ export class PoRepService {
     return count;
   }
 
-  public async getOnboardedDataHistory(
-    windowSize: WindowSize,
-  ): Promise<PoRepDealsOnboardedDataHistory> {
+  public async getOnboardedDataHistory({
+    windowSize = 'day',
+  }: PoRepHistoryParameters): Promise<PoRepOnboardedDataHistoryEntry[]> {
     const results = await this.prismaService.$queryRawTyped(
       getPoRepOnboardedDataHistory(windowSize, this.isTestnet()),
     );
 
     return results.map((result) => {
       return {
-        date: DateTime.fromJSDate(result.window_start, { zone: 'UTC' }),
-        volume: BigInt(result.window_total.toString()),
-        cumulativeTotal: BigInt(result.cumulative_total.toString()),
+        date: DateTime.fromJSDate(result.window_start, {
+          zone: 'UTC',
+        }).toISODate(),
+        volume: result.window_total.toString(),
+        cumulativeTotal: result.cumulative_total.toString(),
       };
     });
   }
 
-  public async getDealsValueHistory(
-    windowSize: WindowSize,
-  ): Promise<PoRepDealsValueHistory> {
+  public async getDealsValueHistory({
+    windowSize = 'day',
+  }: PoRepHistoryParameters): Promise<PoRepDealsValueHistoryEntry[]> {
     const data = await this.prismaService.$queryRawTyped(
       getPoRepDealsValueHistory(windowSize, this.isTestnet()),
     );
@@ -285,6 +234,7 @@ export class PoRepService {
       Promise.all(tokenInfoRequests),
       Promise.all(tokenExchangeRateRequests),
     ]);
+
     const tokensInfo = tokenInfoResponses.reduce((result, tokenInfo) => {
       const [address, symbol, decimals] = tokenInfo;
       return result.set(address, {
@@ -297,70 +247,46 @@ export class PoRepService {
 
     const dataByWindow = groupBy(
       data.filter((item) => item.window_start !== null),
-      (item) => item.window_start.toISOString(),
+      (item) => DateTime.fromJSDate(item.window_start).toISODate(),
     );
 
-    // DB query returns window data per token so we need to convert values in
-    // token units to USD and sum them for each window
-    const combinedWindowData = Object.entries(
-      dataByWindow,
-    ).map<PoRepDealsValueHistoryEntry>(([dateISOString, windowResults]) => {
-      const [windowAmountUSD, cumulativeAmountUSD] = windowResults.reduce(
-        ([currentWindowAmountUSD, currentCumulativeAmountUSD], result) => {
-          const tokenUSDExchangeRate = tokensUSDExchangeRates.get(
-            result.token_address,
-          );
-          const tokenInfo = tokensInfo.get(result.token_address);
-
-          // Should not happen but type safety
-          if (!tokenUSDExchangeRate || !tokenInfo) {
-            throw new Error(
-              `Exchange rate or info not found for token "${result.token_address}"`,
-            );
-          }
-
-          const tokenExponent = Math.pow(10, tokenInfo.decimals);
-          const tokenDailyAmountUSD = result.window_total
-            .div(tokenExponent)
-            .mul(tokenUSDExchangeRate);
-          const tokenCumulativeAmountUSD = result.cumulative_amount
-            .div(tokenExponent)
-            .mul(tokenUSDExchangeRate);
-
-          return [
-            currentWindowAmountUSD.add(tokenDailyAmountUSD),
-            currentCumulativeAmountUSD.add(tokenCumulativeAmountUSD),
-          ];
-        },
-        [new Decimal(0), new Decimal(0)],
-      );
-
-      return {
-        date: DateTime.fromISO(dateISOString, { zone: 'utc' }),
-        volumeUSD: windowAmountUSD.toDecimalPlaces(2).toNumber(),
-        cumulativeTotalUSD: cumulativeAmountUSD.toDecimalPlaces(2).toNumber(),
-      };
-    });
-
-    const combinedWindowDataByISODate = new Map(
-      combinedWindowData.map((item) => [item.date.toISODate(), item]),
-    );
-
-    return [...new Array(entriesCount)].reduce<PoRepDealsValueHistory>(
+    return [...new Array(entriesCount)].reduce<PoRepDealsValueHistoryEntry[]>(
       (result, _, index) => {
-        const entryDay = startDate.plus({ [windowSize]: index });
-        const entryISODate = entryDay.toISODate();
-        const matchingData = combinedWindowDataByISODate.get(entryISODate);
+        const entryDate = startDate.plus({ [windowSize]: index });
+        const entryISODate = entryDate.toISODate();
+        const dataForWindow = dataByWindow[entryISODate] ?? [];
 
-        if (matchingData) {
-          return [...result, matchingData];
-        }
+        const windowVolumeUSD = dataForWindow
+          .reduce((currentWindowVolumeUSD, result) => {
+            const tokenUSDExchangeRate = tokensUSDExchangeRates.get(
+              result.token_address,
+            );
+            const tokenInfo = tokensInfo.get(result.token_address);
+
+            // Should not happen but type safety
+            if (!tokenUSDExchangeRate || !tokenInfo) {
+              throw new Error(
+                `Exchange rate or info not found for token "${result.token_address}"`,
+              );
+            }
+
+            const tokenExponent = Math.pow(10, tokenInfo.decimals);
+            const tokenWindowTotalUSD = result.window_total
+              .div(tokenExponent)
+              .mul(tokenUSDExchangeRate);
+
+            return currentWindowVolumeUSD.add(tokenWindowTotalUSD);
+          }, new Decimal(0))
+          .toDecimalPlaces(2)
+          .toNumber();
 
         const previousEntry = index === 0 ? undefined : result.at(index - 1);
+        const previousTotalUSD = previousEntry?.cumulativeTotalUSD ?? 0;
+
         const nextEntry: PoRepDealsValueHistoryEntry = {
-          date: entryDay,
-          volumeUSD: 0,
-          cumulativeTotalUSD: previousEntry?.cumulativeTotalUSD ?? 0,
+          date: entryISODate,
+          volumeUSD: windowVolumeUSD,
+          cumulativeTotalUSD: previousTotalUSD + windowVolumeUSD,
         };
 
         return [...result, nextEntry];
@@ -370,45 +296,144 @@ export class PoRepService {
   }
 
   public async getSLIComplianceHistory({
-    windowSize,
+    windowSize = 'day',
     sliType,
-    providerId,
+    providerId: providerIdFilter,
     dealId,
-  }: SLIComplianceHistoryParameters): Promise<
-    getPoRepSLIComplianceHistory.Result[]
+  }: PoRepSLIComplianceHistoryParameters): Promise<
+    PoRepSLIComplianceHistoryEntry[]
   > {
-    return this.prismaService.$queryRawTyped(
+    const providerId =
+      providerIdFilter !== undefined ? F0Id.from(providerIdFilter) : null;
+
+    const results = await this.prismaService.$queryRawTyped(
       getPoRepSLIComplianceHistory(
         windowSize,
         this.isTestnet(),
-        sliType,
-        providerId,
-        dealId,
+        this.mapSLIType(sliType),
+        providerId ? providerId.toBigInt() : null,
+        dealId ? BigInt(dealId) : null,
       ),
     );
+
+    const grouped = groupBy(results, (result) =>
+      DateTime.fromJSDate(result.window_start).toISODate(),
+    );
+
+    const states = [
+      'compliant',
+      'nonCompliant',
+      'unknown',
+    ] as const satisfies Omit<keyof PoRepSLIComplianceHistoryEntry, 'date'>[];
+
+    return Object.entries(grouped)
+      .slice(0, -1)
+      .map<PoRepSLIComplianceHistoryEntry>(([dateISOString, results]) => {
+        const [totalProvidersCount, totalDealsCount, totalDealsSize] =
+          results.reduce(
+            (totals, result) => {
+              return [
+                totals[0] + result.providers_count,
+                totals[1] + result.deals_count,
+                totals[2].add(result.total_deals_size),
+              ];
+            },
+            [0, 0, Decimal(0)],
+          );
+
+        const stateEntries = states.map((state) => {
+          const stateResult = results.find(
+            (c) => c.compliance_state.toLowerCase() === state.toLowerCase(),
+          );
+
+          if (!stateResult) {
+            return [
+              state,
+              {
+                providersCount: 0,
+                providersPercentage: 0,
+                dealsCount: 0,
+                dealsPercentage: 0,
+                totalDealsSize: '0',
+                totalDealsSizePercentage: 0,
+              },
+            ];
+          }
+
+          return [
+            state,
+            {
+              providersCount: stateResult.providers_count,
+              providersPercentage: safeDiv(
+                stateResult.providers_count,
+                totalProvidersCount,
+                0,
+              ),
+              dealsCount: stateResult.deals_count,
+              dealsPercentage: safeDiv(
+                stateResult.deals_count,
+                totalDealsCount,
+                0,
+              ),
+              totalDealsSize: stateResult.total_deals_size.toString(),
+              totalDealsSizePercentage: totalDealsSize.eq(0)
+                ? 0
+                : stateResult.total_deals_size.div(totalDealsSize).toNumber(),
+            },
+          ] as const;
+        });
+
+        return {
+          date: dateISOString,
+          ...(Object.fromEntries(stateEntries) as Omit<
+            PoRepSLIComplianceHistoryEntry,
+            'date'
+          >),
+        };
+      });
   }
 
   public async getActiveClientsHistory({
-    windowSize,
+    windowSize = 'day',
     providerId,
-  }: ActiveClientsHistoryParameters): Promise<
-    getPoRepActiveClientsHistory.Result[]
+  }: PoRepActiveClientsHistoryParameters): Promise<
+    PoRepActiveClientsHistoryEntry[]
   > {
     const providerIdBigInt =
       providerId !== null && providerId !== undefined
         ? F0Id.from(providerId).toBigInt()
         : null;
 
-    return this.prismaService.$queryRawTyped(
+    const results = await this.prismaService.$queryRawTyped(
       getPoRepActiveClientsHistory(
         windowSize,
         this.isTestnet(),
         providerIdBigInt,
       ),
     );
+
+    return results.map((result) => ({
+      date: DateTime.fromJSDate(result.window_start).toISODate(),
+      activeClientsCount: result.active_clients_count,
+    }));
   }
 
   private isTestnet(): boolean {
     return this.recentNodeClient.chain.id === filecoinCalibration.id;
+  }
+
+  private mapSLIType(
+    poRepSLIType: PoRepSLIType | undefined,
+  ): StorageProviderUrlFinderMetricType {
+    switch (poRepSLIType) {
+      case 'bandwidthMbps':
+        return StorageProviderUrlFinderMetricType.BANDWIDTH;
+      case 'indexingPct':
+        return null; // Not measured
+      case 'latencyMs':
+        return StorageProviderUrlFinderMetricType.TTFB;
+      case 'retrievabilityBps':
+        return StorageProviderUrlFinderMetricType.RPA_RETRIEVABILITY;
+    }
   }
 }

--- a/src/service/po-rep/po-rep.service.ts
+++ b/src/service/po-rep/po-rep.service.ts
@@ -109,7 +109,8 @@ export class PoRepService {
 
     const dataByWindow = groupBy(
       data.filter((item) => item.window_start !== null),
-      (item) => DateTime.fromJSDate(item.window_start).toISODate(),
+      (item) =>
+        DateTime.fromJSDate(item.window_start, { zone: 'UTC' }).toISODate(),
     );
 
     return [...new Array(entriesCount)].reduce<
@@ -247,7 +248,8 @@ export class PoRepService {
 
     const dataByWindow = groupBy(
       data.filter((item) => item.window_start !== null),
-      (item) => DateTime.fromJSDate(item.window_start).toISODate(),
+      (item) =>
+        DateTime.fromJSDate(item.window_start, { zone: 'UTC' }).toISODate(),
     );
 
     return [...new Array(entriesCount)].reduce<PoRepDealsValueHistoryEntry[]>(
@@ -317,7 +319,7 @@ export class PoRepService {
     );
 
     const grouped = groupBy(results, (result) =>
-      DateTime.fromJSDate(result.window_start).toISODate(),
+      DateTime.fromJSDate(result.window_start, { zone: 'UTC' }).toISODate(),
     );
 
     const states = [
@@ -413,7 +415,9 @@ export class PoRepService {
     );
 
     return results.map((result) => ({
-      date: DateTime.fromJSDate(result.window_start).toISODate(),
+      date: DateTime.fromJSDate(result.window_start, {
+        zone: 'UTC',
+      }).toISODate(),
       activeClientsCount: result.active_clients_count,
     }));
   }

--- a/src/service/po-rep/po-rep.service.ts
+++ b/src/service/po-rep/po-rep.service.ts
@@ -120,8 +120,8 @@ export class PoRepService {
       const entryISODate = entryDate.toISODate();
       const dataForWindow = dataByWindow[entryISODate] ?? [];
 
-      const windowVolumeUSD = dataForWindow
-        .reduce((currentWindowVolumeUSD, result) => {
+      const windowVolumeUSD = dataForWindow.reduce(
+        (currentWindowVolumeUSD, result) => {
           const tokenUSDExchangeRate = tokensUSDExchangeRates.get(
             result.token_address,
           );
@@ -140,17 +140,22 @@ export class PoRepService {
             .mul(tokenUSDExchangeRate);
 
           return currentWindowVolumeUSD.add(tokenWindowTotalUSD);
-        }, new Decimal(0))
-        .toDecimalPlaces(2)
-        .toNumber();
+        },
+        Decimal(0),
+      );
 
       const previousEntry = index === 0 ? undefined : result.at(index - 1);
-      const previousTotalUSD = previousEntry?.cumulativeTotalUSD ?? 0;
+      const previousTotalUSD = previousEntry
+        ? Decimal(previousEntry.cumulativeTotalUSD)
+        : Decimal(0);
 
       const nextEntry: PoRepDealsPaymentsHistoryEntry = {
         date: entryISODate,
-        volumeUSD: windowVolumeUSD,
-        cumulativeTotalUSD: previousTotalUSD + windowVolumeUSD,
+        volumeUSD: windowVolumeUSD.toDecimalPlaces(2).toNumber(),
+        cumulativeTotalUSD: previousTotalUSD
+          .add(windowVolumeUSD)
+          .toDecimalPlaces(2)
+          .toNumber(),
       };
 
       return [...result, nextEntry];
@@ -258,8 +263,8 @@ export class PoRepService {
         const entryISODate = entryDate.toISODate();
         const dataForWindow = dataByWindow[entryISODate] ?? [];
 
-        const windowVolumeUSD = dataForWindow
-          .reduce((currentWindowVolumeUSD, result) => {
+        const windowVolumeUSD = dataForWindow.reduce(
+          (currentWindowVolumeUSD, result) => {
             const tokenUSDExchangeRate = tokensUSDExchangeRates.get(
               result.token_address,
             );
@@ -278,17 +283,22 @@ export class PoRepService {
               .mul(tokenUSDExchangeRate);
 
             return currentWindowVolumeUSD.add(tokenWindowTotalUSD);
-          }, new Decimal(0))
-          .toDecimalPlaces(2)
-          .toNumber();
+          },
+          Decimal(0),
+        );
 
         const previousEntry = index === 0 ? undefined : result.at(index - 1);
-        const previousTotalUSD = previousEntry?.cumulativeTotalUSD ?? 0;
+        const previousTotalUSD = previousEntry
+          ? Decimal(previousEntry.cumulativeTotalUSD)
+          : Decimal(0);
 
         const nextEntry: PoRepDealsValueHistoryEntry = {
           date: entryISODate,
-          volumeUSD: windowVolumeUSD,
-          cumulativeTotalUSD: previousTotalUSD + windowVolumeUSD,
+          volumeUSD: windowVolumeUSD.toDecimalPlaces(2).toNumber(),
+          cumulativeTotalUSD: previousTotalUSD
+            .add(windowVolumeUSD)
+            .toDecimalPlaces(2)
+            .toNumber(),
         };
 
         return [...result, nextEntry];

--- a/src/service/po-rep/types.po-rep.ts
+++ b/src/service/po-rep/types.po-rep.ts
@@ -99,7 +99,7 @@ export class PoRepSLIComplianceHistoryParameters {
     description: 'SLI type to filter by, leave empty to include all',
     required: false,
     enum: poRepSLITypes,
-    enumName: 'PoREpSLIType',
+    enumName: 'PoRepSLIType',
   })
   @IsOptional()
   @IsIn(poRepSLITypes)

--- a/src/service/po-rep/types.po-rep.ts
+++ b/src/service/po-rep/types.po-rep.ts
@@ -1,0 +1,208 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsIn, IsOptional } from 'class-validator';
+import { F0IdInput, IsBigIntLike, IsF0IdInput } from 'src/utils/validators';
+
+export type PoRepSLIType = (typeof poRepSLITypes)[number];
+
+export const poRepHistoryWindowSize = ['day', 'week', 'month'] as const;
+export const poRepSLITypes = [
+  'retrievabilityBps',
+  'bandwidthMbps',
+  'latencyMs',
+  'indexingPct',
+] as const;
+
+export class PoRepHistoryParameters {
+  @ApiProperty({
+    description: 'Window size of returned data, eg. "week"',
+    enum: poRepHistoryWindowSize,
+    enumName: 'PoRepHistoryWindowSize',
+    required: false,
+    default: 'day',
+  })
+  @IsOptional()
+  @IsIn(poRepHistoryWindowSize)
+  windowSize?: (typeof poRepHistoryWindowSize)[number];
+}
+
+// Onboarded data history
+export class PoRepOnboardedDataHistoryEntry {
+  @ApiProperty({
+    description: 'Entry date',
+  })
+  date: string;
+
+  @ApiProperty({
+    description: 'Entry volume of onboarded data in bytes',
+  })
+  volume: string;
+
+  @ApiProperty({
+    description:
+      'Cumulative amount of onboarded data in bytes, up to the entry date',
+  })
+  cumulativeTotal: string;
+}
+
+// Deals value history
+export class PoRepDealsValueHistoryEntry {
+  @ApiProperty({
+    description: 'Window start ISO date (UTC)',
+  })
+  date: string;
+
+  @ApiProperty({
+    description: 'Total value of deals accepted in entry window in USD',
+  })
+  volumeUSD: number;
+
+  @ApiProperty({
+    description:
+      'Cumulative total value of accepted deals in USD, up to entry date',
+  })
+  cumulativeTotalUSD: number;
+}
+
+// Deals payments history
+export class PoRepDealsPaymentsHistoryEntry {
+  @ApiProperty({
+    description: 'Window start ISO date (UTC)',
+  })
+  date: string;
+
+  @ApiProperty({
+    description: 'Daily volume of payments in USD',
+  })
+  volumeUSD: number;
+
+  @ApiProperty({
+    description:
+      'Cumulative amount of payments in USD up to the given window end date',
+  })
+  cumulativeTotalUSD: number;
+}
+
+// SLI compliance history
+export class PoRepSLIComplianceHistoryParameters {
+  @ApiPropertyOptional({
+    description: 'History window interval, default is one day window',
+    enum: poRepHistoryWindowSize,
+    enumName: 'PoRepHistoryWindowSize',
+    required: false,
+    default: 'day',
+  })
+  @IsOptional()
+  @IsIn(poRepHistoryWindowSize)
+  windowSize?: 'day' | 'week' | 'month';
+
+  @ApiPropertyOptional({
+    description: 'SLI type to filter by, leave empty to include all',
+    required: false,
+    enum: poRepSLITypes,
+    enumName: 'PoREpSLIType',
+  })
+  @IsOptional()
+  @IsIn(poRepSLITypes)
+  sliType?: PoRepSLIType;
+
+  @ApiPropertyOptional({
+    description: 'Provider ID to filter by, no filter by default',
+    required: false,
+    type: 'string',
+  })
+  @IsOptional()
+  @IsF0IdInput()
+  providerId?: F0IdInput;
+
+  @ApiPropertyOptional({
+    description: 'Deal ID to filter by, no filter by default',
+    required: false,
+  })
+  @IsOptional()
+  @IsBigIntLike()
+  dealId?: string;
+}
+
+export class PoRepSLIComplianceHistoryStateValues {
+  @ApiProperty({
+    description:
+      'Number of providers having at least one deal matching given state',
+  })
+  providersCount: number;
+
+  @ApiProperty({
+    description:
+      'Percentage of providers having at least one deal matching given state',
+  })
+  providersPercentage: number;
+
+  @ApiProperty({
+    description: 'Number of deals matching given state',
+  })
+  dealsCount: number;
+
+  @ApiProperty({
+    description: 'Percentage of deals matching given state',
+  })
+  dealsPercentage: number;
+
+  @ApiProperty({
+    description: 'Total size of deals matching given state in bytes',
+  })
+  totalDealsSize: string;
+
+  @ApiProperty({
+    description: 'Percentage of deals size matching given state',
+  })
+  totalDealsSizePercentage: number;
+}
+
+export class PoRepSLIComplianceHistoryEntry {
+  @ApiProperty({
+    description: 'Window start ISO date (UTC)',
+  })
+  date: string;
+
+  @ApiProperty({
+    description:
+      'Values for compliant deals. Compliant deals are those for which all selected SLIs were met in given window.',
+  })
+  compliant: PoRepSLIComplianceHistoryStateValues;
+
+  @ApiProperty({
+    description:
+      'Values for non-compliant deals. Non-compliant deals are those for which any of the selected SLIs were not met in given window.',
+  })
+  nonCompliant: PoRepSLIComplianceHistoryStateValues;
+
+  @ApiProperty({
+    description:
+      'Values for unknown state deals. Unknown deals are those for which any of the selected SLIs were not measured at least once in given window.',
+  })
+  unknown: PoRepSLIComplianceHistoryStateValues;
+}
+
+// Active clients history
+export class PoRepActiveClientsHistoryParameters extends PoRepHistoryParameters {
+  @ApiPropertyOptional({
+    description: 'Provider ID to filter by, no filter by default',
+    required: false,
+    type: 'string',
+  })
+  @IsOptional()
+  @IsF0IdInput()
+  providerId?: F0IdInput;
+}
+
+export class PoRepActiveClientsHistoryEntry {
+  @ApiProperty({
+    description: 'Window start ISO date (UTC)',
+  })
+  date: string;
+
+  @ApiProperty({
+    description:
+      'Count of active clients in a window. Client is considered active if they have at least one deal completed before or during the window, that was not terminated before window start.',
+  })
+  activeClientsCount: number;
+}


### PR DESCRIPTION
- Updated SQL queries to change column aliases for clarity in `getFilecoinPaymentsForDealsHistory.sql` and `getPoRepDealsValueHistory.sql`.
- Removed cumulative amount calculations from SQL queries in `getFilecoinPaymentsForDealsHistory.sql` and `getPoRepDealsValueHistory.sql`.
- Refactored `PoRepController` to streamline data retrieval methods, replacing manual mapping with direct service calls.
- Consolidated and organized types in `types.po-rep.ts`, removing redundant interfaces and ensuring consistency across parameters.
- Enhanced type safety and clarity in the `PoRepService` methods for fetching deals and compliance history.